### PR TITLE
fix: fcm receive push

### DIFF
--- a/Remote Habits/AppDelegateFCM.swift
+++ b/Remote Habits/AppDelegateFCM.swift
@@ -27,15 +27,25 @@
 //        // to be called.
 //        UNUserNotificationCenter.current().delegate = self
 //
-//        // Set FCM messaging delegate
-//        Messaging.messaging().delegate = self
-//
 //        // It's good practice to always register for remote push when the app starts.
 //        // This asserts that the Customer.io SDK always has a valid APN device token to use.
 //        UIApplication.shared.registerForRemoteNotifications()
 //
+//        // Set FCM messaging delegate after registering for APN push notifications.
+//        Messaging.messaging().delegate = self
+//
 //        return true
 //    }
+//
+//     func application(_ application: UIApplication,
+//                      didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
+//         let logger = DI.shared.logger
+//
+//         logger.log("Received APN token: \(String(apnDeviceToken: deviceToken))")
+//
+//         // because we disabled FCM method swizzling, we need to provide the APN token to the FCM SDK.
+//         Messaging.messaging().apnsToken = deviceToken
+//     }
 // }
 //
 // extension AppDelegateFCM: MessagingDelegate {
@@ -51,6 +61,8 @@
 //        // So, we are saving the device token for later when a profile is identified in the app to register
 //        // a device token to the profile then.
 //        userManager.fcmDeviceToken = fcmToken
+//
+//        logger.log("Received FCM token: \(fcmToken)")
 //
 //        // Customer.io SDK will return an error when attempting to register a device token if a profile has
 //        // not been identified with Customer.io yet. Therefore, we check if a profile has been identified yet.

--- a/Remote Habits/Info.plist
+++ b/Remote Habits/Info.plist
@@ -4,6 +4,8 @@
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>FirebaseAppDelegateProxyEnabled</key>
+	<false/>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>

--- a/docs/dev-notes/DEVELOPMENT.md
+++ b/docs/dev-notes/DEVELOPMENT.md
@@ -103,3 +103,5 @@ The Remote Habits app is setup to only work with APN at this time. You must foll
 3. Open the file `RemoteHabitsApp` and follow the instructions for enabling FCM's AppDelegate. 
 
 4. If you have the Remote Habits app installed on your device right now using APN, you should delete the app and re-install this FCM build. 
+
+> Note: [This guide](https://www.raywenderlich.com/20201639-firebase-cloud-messaging-for-ios-push-notifications) was followed to help get FCM setup with SwiftUI. The [official FCM docs](https://firebase.google.com/docs/cloud-messaging/ios/client) do not cover how to get FCM setup with an app that uses SwiftUI and [there is a bug](https://github.com/firebase/firebase-ios-sdk/issues/8738) in the FCM SDK when building a SwiftUI app. The biggest change is [disabling method swizzling](https://firebase.google.com/docs/cloud-messaging/ios/client#method_swizzling_in) for the FCM SDK. When method swizzling was enabled, an APN token was never retrieved for the app. 


### PR DESCRIPTION
The app is able to receive a FCM device token but when trying to send a push notification to the device, a push is not received. 

Through debugging, I discovered that the FCM SDK is [not properly setup to work with SwiftUI apps](https://github.com/firebase/firebase-ios-sdk/issues/8738) like this app is. The solution is to disable method swizzling in the FCM SDK and manually call the functions of the FCM SDK. 

To test these changes, follow the instructions [in the development docs](https://github.com/customerio/RemoteHabits-iOS/blob/main/docs/dev-notes/DEVELOPMENT.md) for FCM testing. 