### PR TITLE
fix: track user activity in remote habits app

### DIFF
--- a/Remote Habits/ViewModel/TrackerViewModel.swift
+++ b/Remote Habits/ViewModel/TrackerViewModel.swift
@@ -10,8 +10,9 @@ class TrackerViewModel: ObservableObject {
     }
 
     func trackHabitActivity(withName habitName: String, forHabit habitActivity: SelectedHabitData) {
-        guard let title = habitActivity.title, let freq = habitActivity.frequency,
-              let starttime = habitActivity.startTime, let endtime = habitActivity.endTime else { return }
+        guard let title = habitActivity.title, let freq = habitActivity.frequency else { return }
+        let starttime = habitActivity.startTime ?? Date().formatDateToString(inFormat: .time12Hour)
+        let endtime = habitActivity.endTime ?? Date().formatDateToString(inFormat: .time12Hour)
         let param = ["title": title, "frequency": "\(freq)", "startTime": starttime, "endTime": endtime]
         cio.track(name: habitName, data: param, jsonEncoder: nil)
     }


### PR DESCRIPTION
Minor fix for track user activity in remote habits app.

The app was not able to track the user activities because default start time and end time is nil which is intentional.
Reason :
- Show current time in case start time or end time is nil
- Once user selects a time then show new time 

 In case the user does not change start time or end time for any activity, the time was nil which was stopping the app to track because of guard statement.
 
 Fix - In case, start or end time is nil, the function will have current time as start or end time.