### PR TITLE
refactor: removed prefix RH from file names

### DIFF
--- a/Remote Habits.xcodeproj/project.pbxproj
+++ b/Remote Habits.xcodeproj/project.pbxproj
@@ -50,22 +50,22 @@
 		463D95EF2758E2FE000FF356 /* StringExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 463D95EB2758E2E6000FF356 /* StringExtensions.swift */; };
 		463D95FC2758E45A000FF356 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 463D95F82758E45A000FF356 /* Main.storyboard */; };
 		463D95FD2758E45A000FF356 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 463D95FA2758E45A000FF356 /* LaunchScreen.storyboard */; };
-		463D96012758E94A000FF356 /* RHFont+Color.swift in Sources */ = {isa = PBXBuildFile; fileRef = 463D95FF2758E94A000FF356 /* RHFont+Color.swift */; };
-		463D96022758E94A000FF356 /* RHConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 463D96002758E94A000FF356 /* RHConstants.swift */; };
-		463D96052758E985000FF356 /* RHStubData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 463D96042758E985000FF356 /* RHStubData.swift */; };
+		463D96012758E94A000FF356 /* Font+Color.swift in Sources */ = {isa = PBXBuildFile; fileRef = 463D95FF2758E94A000FF356 /* Font+Color.swift */; };
+		463D96022758E94A000FF356 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 463D96002758E94A000FF356 /* Constants.swift */; };
+		463D96052758E985000FF356 /* StubData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 463D96042758E985000FF356 /* StubData.swift */; };
 		463D960D2758E9C9000FF356 /* SF-Pro-Text-Semibold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 463D96072758E9C8000FF356 /* SF-Pro-Text-Semibold.otf */; };
 		463D960E2758E9C9000FF356 /* SFPRODISPLAYBOLD.OTF in Resources */ = {isa = PBXBuildFile; fileRef = 463D96082758E9C8000FF356 /* SFPRODISPLAYBOLD.OTF */; };
 		463D960F2758E9C9000FF356 /* SFPRODISPLAYREGULAR.OTF in Resources */ = {isa = PBXBuildFile; fileRef = 463D96092758E9C8000FF356 /* SFPRODISPLAYREGULAR.OTF */; };
 		463D96102758E9C9000FF356 /* SF-Pro-Text-Bold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 463D960A2758E9C8000FF356 /* SF-Pro-Text-Bold.otf */; };
 		463D96112758E9C9000FF356 /* SF-Pro-Text-Regular.otf in Resources */ = {isa = PBXBuildFile; fileRef = 463D960B2758E9C9000FF356 /* SF-Pro-Text-Regular.otf */; };
 		463D96122758E9C9000FF356 /* fontawesome-webfont.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 463D960C2758E9C9000FF356 /* fontawesome-webfont.ttf */; };
-		463D96162758E9FD000FF356 /* RHBaseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 463D96152758E9FD000FF356 /* RHBaseViewController.swift */; };
-		463D96192758EA31000FF356 /* RHCustomisedTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 463D96182758EA31000FF356 /* RHCustomisedTableView.swift */; };
-		463D961C2758EA54000FF356 /* RHHabitDashboardProtocolHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 463D961B2758EA54000FF356 /* RHHabitDashboardProtocolHandler.swift */; };
-		463D96212758EA71000FF356 /* RHHabitDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 463D961D2758EA71000FF356 /* RHHabitDetailViewController.swift */; };
-		463D96222758EA71000FF356 /* RHDashboardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 463D961E2758EA71000FF356 /* RHDashboardViewController.swift */; };
-		463D96232758EA71000FF356 /* RHSwitchWorkspaceViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 463D961F2758EA71000FF356 /* RHSwitchWorkspaceViewController.swift */; };
-		463D96242758EA71000FF356 /* RHLoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 463D96202758EA71000FF356 /* RHLoginViewController.swift */; };
+		463D96162758E9FD000FF356 /* BaseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 463D96152758E9FD000FF356 /* BaseViewController.swift */; };
+		463D96192758EA31000FF356 /* CustomisedTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 463D96182758EA31000FF356 /* CustomisedTableView.swift */; };
+		463D961C2758EA54000FF356 /* HabitDashboardProtocolHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 463D961B2758EA54000FF356 /* HabitDashboardProtocolHandler.swift */; };
+		463D96212758EA71000FF356 /* HabitDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 463D961D2758EA71000FF356 /* HabitDetailViewController.swift */; };
+		463D96222758EA71000FF356 /* DashboardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 463D961E2758EA71000FF356 /* DashboardViewController.swift */; };
+		463D96232758EA71000FF356 /* SwitchWorkspaceViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 463D961F2758EA71000FF356 /* SwitchWorkspaceViewController.swift */; };
+		463D96242758EA71000FF356 /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 463D96202758EA71000FF356 /* LoginViewController.swift */; };
 		463D96292758EA9F000FF356 /* HabitTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 463D96272758EA9F000FF356 /* HabitTableViewCell.swift */; };
 		463D962A2758EA9F000FF356 /* HabitTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 463D96282758EA9F000FF356 /* HabitTableViewCell.xib */; };
 		463D96322758EACD000FF356 /* HabitReminderTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 463D962C2758EACC000FF356 /* HabitReminderTableViewCell.xib */; };
@@ -91,7 +91,7 @@
 		465F764E277497F7000A6C49 /* DateExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 465F7637276A46F7000A6C49 /* DateExtensions.swift */; };
 		466FEADC2762693000997AE7 /* TextFieldExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 466FEADB2762693000997AE7 /* TextFieldExtension.swift */; };
 		4698F3DE2760D10900EE48F3 /* SkyFloatingLabelTextField in Frameworks */ = {isa = PBXBuildFile; productRef = 4698F3DD2760D10900EE48F3 /* SkyFloatingLabelTextField */; };
-		46A6CCBC277F3C3D007820B3 /* RHFont+Color.swift in Sources */ = {isa = PBXBuildFile; fileRef = 463D95FF2758E94A000FF356 /* RHFont+Color.swift */; };
+		46A6CCBC277F3C3D007820B3 /* Font+Color.swift in Sources */ = {isa = PBXBuildFile; fileRef = 463D95FF2758E94A000FF356 /* Font+Color.swift */; };
 		46FEC8D92758D34100A6A03F /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46FEC8CF2758D34100A6A03F /* AppDelegate.swift */; };
 		46FEC8DB2758D34100A6A03F /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46FEC8D12758D34100A6A03F /* SceneDelegate.swift */; };
 		46FEC8DE2758D4C500A6A03F /* Tracking in Frameworks */ = {isa = PBXBuildFile; productRef = 46FEC8DD2758D4C500A6A03F /* Tracking */; };
@@ -174,22 +174,22 @@
 		463D95F02758E390000FF356 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		463D95F92758E45A000FF356 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		463D95FB2758E45A000FF356 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
-		463D95FF2758E94A000FF356 /* RHFont+Color.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "RHFont+Color.swift"; sourceTree = "<group>"; };
-		463D96002758E94A000FF356 /* RHConstants.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RHConstants.swift; sourceTree = "<group>"; };
-		463D96042758E985000FF356 /* RHStubData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RHStubData.swift; sourceTree = "<group>"; };
+		463D95FF2758E94A000FF356 /* Font+Color.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Font+Color.swift"; sourceTree = "<group>"; };
+		463D96002758E94A000FF356 /* Constants.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
+		463D96042758E985000FF356 /* StubData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StubData.swift; sourceTree = "<group>"; };
 		463D96072758E9C8000FF356 /* SF-Pro-Text-Semibold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SF-Pro-Text-Semibold.otf"; sourceTree = "<group>"; };
 		463D96082758E9C8000FF356 /* SFPRODISPLAYBOLD.OTF */ = {isa = PBXFileReference; lastKnownFileType = file; path = SFPRODISPLAYBOLD.OTF; sourceTree = "<group>"; };
 		463D96092758E9C8000FF356 /* SFPRODISPLAYREGULAR.OTF */ = {isa = PBXFileReference; lastKnownFileType = file; path = SFPRODISPLAYREGULAR.OTF; sourceTree = "<group>"; };
 		463D960A2758E9C8000FF356 /* SF-Pro-Text-Bold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SF-Pro-Text-Bold.otf"; sourceTree = "<group>"; };
 		463D960B2758E9C9000FF356 /* SF-Pro-Text-Regular.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SF-Pro-Text-Regular.otf"; sourceTree = "<group>"; };
 		463D960C2758E9C9000FF356 /* fontawesome-webfont.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "fontawesome-webfont.ttf"; sourceTree = "<group>"; };
-		463D96152758E9FD000FF356 /* RHBaseViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RHBaseViewController.swift; sourceTree = "<group>"; };
-		463D96182758EA31000FF356 /* RHCustomisedTableView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RHCustomisedTableView.swift; sourceTree = "<group>"; };
-		463D961B2758EA54000FF356 /* RHHabitDashboardProtocolHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RHHabitDashboardProtocolHandler.swift; sourceTree = "<group>"; };
-		463D961D2758EA71000FF356 /* RHHabitDetailViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RHHabitDetailViewController.swift; sourceTree = "<group>"; };
-		463D961E2758EA71000FF356 /* RHDashboardViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RHDashboardViewController.swift; sourceTree = "<group>"; };
-		463D961F2758EA71000FF356 /* RHSwitchWorkspaceViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RHSwitchWorkspaceViewController.swift; sourceTree = "<group>"; };
-		463D96202758EA71000FF356 /* RHLoginViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RHLoginViewController.swift; sourceTree = "<group>"; };
+		463D96152758E9FD000FF356 /* BaseViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BaseViewController.swift; sourceTree = "<group>"; };
+		463D96182758EA31000FF356 /* CustomisedTableView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomisedTableView.swift; sourceTree = "<group>"; };
+		463D961B2758EA54000FF356 /* HabitDashboardProtocolHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HabitDashboardProtocolHandler.swift; sourceTree = "<group>"; };
+		463D961D2758EA71000FF356 /* HabitDetailViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HabitDetailViewController.swift; sourceTree = "<group>"; };
+		463D961E2758EA71000FF356 /* DashboardViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DashboardViewController.swift; sourceTree = "<group>"; };
+		463D961F2758EA71000FF356 /* SwitchWorkspaceViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwitchWorkspaceViewController.swift; sourceTree = "<group>"; };
+		463D96202758EA71000FF356 /* LoginViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoginViewController.swift; sourceTree = "<group>"; };
 		463D96272758EA9F000FF356 /* HabitTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HabitTableViewCell.swift; sourceTree = "<group>"; };
 		463D96282758EA9F000FF356 /* HabitTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = HabitTableViewCell.xib; sourceTree = "<group>"; };
 		463D962C2758EACC000FF356 /* HabitReminderTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = HabitReminderTableViewCell.xib; sourceTree = "<group>"; };
@@ -350,8 +350,8 @@
 		463D95FE2758E91F000FF356 /* Common */ = {
 			isa = PBXGroup;
 			children = (
-				463D96002758E94A000FF356 /* RHConstants.swift */,
-				463D95FF2758E94A000FF356 /* RHFont+Color.swift */,
+				463D96002758E94A000FF356 /* Constants.swift */,
+				463D95FF2758E94A000FF356 /* Font+Color.swift */,
 			);
 			path = Common;
 			sourceTree = "<group>";
@@ -359,7 +359,7 @@
 		463D96032758E960000FF356 /* Stub */ = {
 			isa = PBXGroup;
 			children = (
-				463D96042758E985000FF356 /* RHStubData.swift */,
+				463D96042758E985000FF356 /* StubData.swift */,
 			);
 			path = Stub;
 			sourceTree = "<group>";
@@ -381,10 +381,10 @@
 			isa = PBXGroup;
 			children = (
 				463D96252758EA7F000FF356 /* Xib */,
-				463D961E2758EA71000FF356 /* RHDashboardViewController.swift */,
-				463D961D2758EA71000FF356 /* RHHabitDetailViewController.swift */,
-				463D96202758EA71000FF356 /* RHLoginViewController.swift */,
-				463D961F2758EA71000FF356 /* RHSwitchWorkspaceViewController.swift */,
+				463D961E2758EA71000FF356 /* DashboardViewController.swift */,
+				463D961D2758EA71000FF356 /* HabitDetailViewController.swift */,
+				463D96202758EA71000FF356 /* LoginViewController.swift */,
+				463D961F2758EA71000FF356 /* SwitchWorkspaceViewController.swift */,
 				463D961A2758EA3E000FF356 /* Handler */,
 				463D96172758EA07000FF356 /* Customisation */,
 				463D96142758E9EF000FF356 /* Common */,
@@ -395,7 +395,7 @@
 		463D96142758E9EF000FF356 /* Common */ = {
 			isa = PBXGroup;
 			children = (
-				463D96152758E9FD000FF356 /* RHBaseViewController.swift */,
+				463D96152758E9FD000FF356 /* BaseViewController.swift */,
 				462ABD4327886D4200CA4585 /* ToolbarUtil.swift */,
 			);
 			path = Common;
@@ -404,7 +404,7 @@
 		463D96172758EA07000FF356 /* Customisation */ = {
 			isa = PBXGroup;
 			children = (
-				463D96182758EA31000FF356 /* RHCustomisedTableView.swift */,
+				463D96182758EA31000FF356 /* CustomisedTableView.swift */,
 			);
 			path = Customisation;
 			sourceTree = "<group>";
@@ -412,7 +412,7 @@
 		463D961A2758EA3E000FF356 /* Handler */ = {
 			isa = PBXGroup;
 			children = (
-				463D961B2758EA54000FF356 /* RHHabitDashboardProtocolHandler.swift */,
+				463D961B2758EA54000FF356 /* HabitDashboardProtocolHandler.swift */,
 			);
 			path = Handler;
 			sourceTree = "<group>";
@@ -727,7 +727,7 @@
 			files = (
 				463D95B42758DB86000FF356 /* Autogenerated.swift in Sources */,
 				463D95B62758DB8B000FF356 /* AutoMockable.generated.swift in Sources */,
-				46A6CCBC277F3C3D007820B3 /* RHFont+Color.swift in Sources */,
+				46A6CCBC277F3C3D007820B3 /* Font+Color.swift in Sources */,
 				463D95B52758DB88000FF356 /* AutoLenses.generated.swift in Sources */,
 				463D95DC2758DE64000FF356 /* ProfileRepository.swift in Sources */,
 				463D95DB2758DE5F000FF356 /* UserManager.swift in Sources */,
@@ -759,29 +759,29 @@
 			buildActionMask = 2147483647;
 			files = (
 				46FEC8D92758D34100A6A03F /* AppDelegate.swift in Sources */,
-				463D96192758EA31000FF356 /* RHCustomisedTableView.swift in Sources */,
-				463D96012758E94A000FF356 /* RHFont+Color.swift in Sources */,
+				463D96192758EA31000FF356 /* CustomisedTableView.swift in Sources */,
+				463D96012758E94A000FF356 /* Font+Color.swift in Sources */,
 				463D95E52758E282000FF356 /* Profile.swift in Sources */,
 				463D96292758EA9F000FF356 /* HabitTableViewCell.swift in Sources */,
 				46FEC8DB2758D34100A6A03F /* SceneDelegate.swift in Sources */,
 				465F764327730AF3000A6C49 /* DataManager.swift in Sources */,
-				463D96222758EA71000FF356 /* RHDashboardViewController.swift in Sources */,
+				463D96222758EA71000FF356 /* DashboardViewController.swift in Sources */,
 				463D95EC2758E2E6000FF356 /* ViewExtension.swift in Sources */,
 				465F76412770DAFB000A6C49 /* RemoteHabits.xcdatamodeld in Sources */,
-				463D961C2758EA54000FF356 /* RHHabitDashboardProtocolHandler.swift in Sources */,
-				463D96242758EA71000FF356 /* RHLoginViewController.swift in Sources */,
+				463D961C2758EA54000FF356 /* HabitDashboardProtocolHandler.swift in Sources */,
+				463D96242758EA71000FF356 /* LoginViewController.swift in Sources */,
 				463D95CD2758DD2B000FF356 /* CustomerIOErrorUtil.swift in Sources */,
 				462ABD4427886D4200CA4585 /* ToolbarUtil.swift in Sources */,
 				463D95D72758DD85000FF356 /* ProfileRepository.swift in Sources */,
-				463D96232758EA71000FF356 /* RHSwitchWorkspaceViewController.swift in Sources */,
+				463D96232758EA71000FF356 /* SwitchWorkspaceViewController.swift in Sources */,
 				466FEADC2762693000997AE7 /* TextFieldExtension.swift in Sources */,
 				463D95ED2758E2E6000FF356 /* StringExtensions.swift in Sources */,
 				463D95CE2758DD2B000FF356 /* UserDefaultKeys.swift in Sources */,
 				463D95B02758DB7D000FF356 /* Autogenerated.swift in Sources */,
 				463D95AF2758DB7D000FF356 /* AutoDependencyInjection.generated.swift in Sources */,
-				463D96022758E94A000FF356 /* RHConstants.swift in Sources */,
-				463D96052758E985000FF356 /* RHStubData.swift in Sources */,
-				463D96162758E9FD000FF356 /* RHBaseViewController.swift in Sources */,
+				463D96022758E94A000FF356 /* Constants.swift in Sources */,
+				463D96052758E985000FF356 /* StubData.swift in Sources */,
+				463D96162758E9FD000FF356 /* BaseViewController.swift in Sources */,
 				465F7638276A46F7000A6C49 /* DateExtensions.swift in Sources */,
 				465F764727732211000A6C49 /* Habits+CoreDataProperties.swift in Sources */,
 				463D96372758EACD000FF356 /* HabitReminderTableViewCell.swift in Sources */,
@@ -792,7 +792,7 @@
 				463D95B22758DB7D000FF356 /* DIDependencies.swift in Sources */,
 				465F763D276B5457000A6C49 /* Env.swift in Sources */,
 				463D95D02758DD2B000FF356 /* Logger.swift in Sources */,
-				463D96212758EA71000FF356 /* RHHabitDetailViewController.swift in Sources */,
+				463D96212758EA71000FF356 /* HabitDetailViewController.swift in Sources */,
 				465F764627732211000A6C49 /* Habits+CoreDataClass.swift in Sources */,
 				463D95DF2758E1E0000FF356 /* ProfileViewModel.swift in Sources */,
 				463D96352758EACD000FF356 /* HabitDetailToggleTableViewCell.swift in Sources */,

--- a/Remote Habits/Base.lproj/Main.storyboard
+++ b/Remote Habits/Base.lproj/Main.storyboard
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina6_1" orientation="portrait" appearance="dark"/>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <dependencies>
-        <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -24,26 +22,26 @@
         <!--Login View Controller-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController storyboardIdentifier="RHLoginViewController" id="BYZ-38-t0r" customClass="RHLoginViewController" customModule="Remote_Habits" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="LoginViewController" id="BYZ-38-t0r" customClass="LoginViewController" customModule="Remote_Habits" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="nbb-Wq-YBp">
-                                <rect key="frame" x="0.0" y="696" width="414" height="200"/>
+                                <rect key="frame" x="0.0" y="400" width="600" height="200"/>
                                 <subviews>
                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="footerbackground" translatesAutoresizingMaskIntoConstraints="NO" id="T4o-Qp-JqZ">
-                                        <rect key="frame" x="0.0" y="0.0" width="414" height="200"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="600" height="200"/>
                                     </imageView>
                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="paperleft" translatesAutoresizingMaskIntoConstraints="NO" id="Mwb-6t-ZaU">
-                                        <rect key="frame" x="347" y="72" width="77" height="100"/>
+                                        <rect key="frame" x="533" y="72" width="77" height="100"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="77" id="EaY-dk-rtd"/>
                                             <constraint firstAttribute="height" constant="100" id="eHC-bn-s5V"/>
                                         </constraints>
                                     </imageView>
                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="computer" translatesAutoresizingMaskIntoConstraints="NO" id="2tc-5x-yKU">
-                                        <rect key="frame" x="107" y="-91" width="200" height="202"/>
+                                        <rect key="frame" x="200" y="-91" width="200" height="202"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="200" id="I2P-Ik-CVM"/>
                                             <constraint firstAttribute="height" constant="202" id="Rrs-mz-kg3"/>
@@ -73,10 +71,10 @@
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="lDa-6J-xfB">
-                                <rect key="frame" x="17" y="204" width="380" height="300"/>
+                                <rect key="frame" x="17" y="203" width="566" height="300"/>
                                 <subviews>
                                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Name" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="zHc-Ff-Nnh" customClass="SkyFloatingLabelTextFieldWithIcon" customModule="SkyFloatingLabelTextField">
-                                        <rect key="frame" x="20" y="25" width="340" height="44"/>
+                                        <rect key="frame" x="20" y="25" width="526" height="44"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="44" id="xna-e2-Zfl"/>
                                         </constraints>
@@ -92,7 +90,7 @@
                                         </connections>
                                     </textField>
                                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Email" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Drq-ms-iTN" customClass="SkyFloatingLabelTextFieldWithIcon" customModule="SkyFloatingLabelTextField">
-                                        <rect key="frame" x="20" y="94" width="340" height="44"/>
+                                        <rect key="frame" x="20" y="94" width="526" height="44"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="44" id="usB-Tp-1mL"/>
                                         </constraints>
@@ -103,7 +101,7 @@
                                         </connections>
                                     </textField>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="6O9-1w-tWa">
-                                        <rect key="frame" x="20" y="244" width="340" height="31"/>
+                                        <rect key="frame" x="20" y="244" width="526" height="31"/>
                                         <state key="normal" title="Button"/>
                                         <buttonConfiguration key="configuration" style="plain" title="Continue as Guest"/>
                                         <connections>
@@ -111,13 +109,13 @@
                                         </connections>
                                     </button>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Some error occurred. Please try again." textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2SO-uo-DS7">
-                                        <rect key="frame" x="20" y="281" width="340" height="18"/>
+                                        <rect key="frame" x="20" y="281" width="526" height="18"/>
                                         <fontDescription key="fontDescription" name="SFProText-Regular" family="SF Pro Text" pointSize="15"/>
                                         <color key="textColor" red="0.99613457918167114" green="0.19977137446403503" blue="0.0042474423535168171" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="cfy-Hr-HB8">
-                                        <rect key="frame" x="20" y="178" width="340" height="46"/>
+                                        <rect key="frame" x="20" y="178" width="526" height="46"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="46" id="2x8-7h-GPx"/>
                                         </constraints>
@@ -149,13 +147,13 @@
                                 </constraints>
                             </view>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Remote Habits" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="RLF-oY-l1G">
-                                <rect key="frame" x="10" y="138" width="394" height="41"/>
+                                <rect key="frame" x="10" y="138" width="580" height="40"/>
                                 <fontDescription key="fontDescription" name="SFProDisplay-Bold" family="SF Pro Display" pointSize="34"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="logo" translatesAutoresizingMaskIntoConstraints="NO" id="9qF-9t-beO">
-                                <rect key="frame" x="-35" y="646" width="77" height="100"/>
+                                <rect key="frame" x="-35" y="350" width="77" height="100"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="100" id="70X-tN-kTZ"/>
                                     <constraint firstAttribute="width" constant="77" id="CSI-yX-3mg"/>
@@ -195,13 +193,13 @@
         <!--Dashboard View Controller-->
         <scene sceneID="doS-eQ-R0a">
             <objects>
-                <viewController storyboardIdentifier="RHDashboardViewController" id="rzf-ws-aIc" customClass="RHDashboardViewController" customModule="Remote_Habits" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="DashboardViewController" id="rzf-ws-aIc" customClass="DashboardViewController" customModule="Remote_Habits" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="APk-3y-D5o">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="s0z-2A-bwk">
-                                <rect key="frame" x="0.0" y="44" width="414" height="818"/>
+                                <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </tableView>
                         </subviews>
@@ -225,19 +223,19 @@
         <!--Habit Detail View Controller-->
         <scene sceneID="l1g-GJ-JNN">
             <objects>
-                <viewController storyboardIdentifier="RHHabitDetailViewController" id="RD8-Lw-EJj" customClass="RHHabitDetailViewController" customModule="Remote_Habits" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="HabitDetailViewController" id="RD8-Lw-EJj" customClass="HabitDetailViewController" customModule="Remote_Habits" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="317-ym-gEB">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="19j-Ej-mS4">
-                                <rect key="frame" x="0.0" y="44" width="414" height="180"/>
+                                <rect key="frame" x="0.0" y="0.0" width="600" height="180"/>
                                 <subviews>
                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="brain" translatesAutoresizingMaskIntoConstraints="NO" id="nsF-KR-GIh">
-                                        <rect key="frame" x="145" y="15" width="124" height="108"/>
+                                        <rect key="frame" x="210" y="15" width="180" height="108"/>
                                     </imageView>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Set reminder to focus" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8DE-KS-BuL">
-                                        <rect key="frame" x="10" y="131" width="394" height="16"/>
+                                        <rect key="frame" x="10" y="131" width="580" height="16"/>
                                         <fontDescription key="fontDescription" name="SFProText-Regular" family="SF Pro Text" pointSize="13"/>
                                         <color key="textColor" red="0.23529411764705882" green="0.23529411764705882" blue="0.2627450980392157" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>
@@ -256,8 +254,8 @@
                                     <constraint firstItem="8DE-KS-BuL" firstAttribute="top" secondItem="nsF-KR-GIh" secondAttribute="bottom" constant="8" id="z7K-C4-Y9h"/>
                                 </constraints>
                             </view>
-                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="80" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="sac-6i-pNg" customClass="RHCustomisedTableView" customModule="Remote_Habits" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="224" width="414" height="638"/>
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="80" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="sac-6i-pNg" customClass="CustomisedTableView" customModule="Remote_Habits" customModuleProvider="target">
+                                <rect key="frame" x="0.0" y="180" width="600" height="420"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </tableView>
                         </subviews>
@@ -305,19 +303,19 @@
         <!--Switch Workspace View Controller-->
         <scene sceneID="5sh-tR-DNm">
             <objects>
-                <viewController storyboardIdentifier="RHSwitchWorkspaceViewController" id="aRg-uH-tBU" customClass="RHSwitchWorkspaceViewController" customModule="Remote_Habits" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="SwitchWorkspaceViewController" id="aRg-uH-tBU" customClass="SwitchWorkspaceViewController" customModule="Remote_Habits" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="waa-E5-r3r">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="7ez-jq-njX">
-                                <rect key="frame" x="0.0" y="44" width="414" height="180"/>
+                                <rect key="frame" x="0.0" y="0.0" width="600" height="180"/>
                                 <subviews>
                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="ciologo" translatesAutoresizingMaskIntoConstraints="NO" id="7Rs-zb-9bE">
-                                        <rect key="frame" x="145" y="15" width="124" height="108"/>
+                                        <rect key="frame" x="210" y="15" width="180" height="108"/>
                                     </imageView>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Customer.io Workspace" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MEJ-co-eyn">
-                                        <rect key="frame" x="134.5" y="131" width="145.5" height="16"/>
+                                        <rect key="frame" x="231" y="131" width="138.5" height="16"/>
                                         <fontDescription key="fontDescription" name="SFProText-Regular" family="SF Pro Text" pointSize="13"/>
                                         <color key="textColor" name="LabelLightGray"/>
                                         <nil key="highlightedColor"/>
@@ -335,10 +333,10 @@
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ZNo-aH-66I">
-                                <rect key="frame" x="17" y="224" width="380" height="290"/>
+                                <rect key="frame" x="17" y="180" width="566" height="290"/>
                                 <subviews>
                                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Site ID" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Kh2-g3-Lmc" customClass="SkyFloatingLabelTextField" customModule="SkyFloatingLabelTextField">
-                                        <rect key="frame" x="16" y="47" width="348" height="44"/>
+                                        <rect key="frame" x="16" y="47" width="534" height="44"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="44" id="cq6-E8-gQX"/>
                                         </constraints>
@@ -355,7 +353,7 @@
                                         </connections>
                                     </textField>
                                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="API Key" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Yof-KK-KUO" customClass="SkyFloatingLabelTextField" customModule="SkyFloatingLabelTextField">
-                                        <rect key="frame" x="16" y="131" width="348" height="44"/>
+                                        <rect key="frame" x="16" y="131" width="534" height="44"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="44" id="udQ-Ot-hxX"/>
                                         </constraints>
@@ -372,13 +370,13 @@
                                         </connections>
                                     </textField>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Oops! Invalid Credentials." textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="htA-do-Z20">
-                                        <rect key="frame" x="16" y="266" width="348" height="18"/>
+                                        <rect key="frame" x="16" y="266" width="534" height="18"/>
                                         <fontDescription key="fontDescription" name="SFProText-Regular" family="SF Pro Text" pointSize="15"/>
                                         <color key="textColor" red="0.99613457918167114" green="0.19977137446403503" blue="0.0042474423535168171" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="azK-hz-wX0">
-                                        <rect key="frame" x="16" y="215" width="348" height="46"/>
+                                        <rect key="frame" x="16" y="215" width="534" height="46"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="46" id="jMY-CR-Gk6"/>
                                         </constraints>
@@ -431,20 +429,6 @@
             <point key="canvasLocation" x="-1886.9565217391305" y="85.714285714285708"/>
         </scene>
     </scenes>
-    <designables>
-        <designable name="Drq-ms-iTN">
-            <size key="intrinsicContentSize" width="39" height="22"/>
-        </designable>
-        <designable name="Kh2-g3-Lmc">
-            <size key="intrinsicContentSize" width="46" height="22"/>
-        </designable>
-        <designable name="Yof-KK-KUO">
-            <size key="intrinsicContentSize" width="55" height="22"/>
-        </designable>
-        <designable name="zHc-Ff-Nnh">
-            <size key="intrinsicContentSize" width="43" height="22"/>
-        </designable>
-    </designables>
     <resources>
         <image name="brain" width="216" height="216"/>
         <image name="ciologo" width="216" height="216"/>

--- a/Remote Habits/Common/Constants.swift
+++ b/Remote Habits/Common/Constants.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct RHConstants {
+struct Constants {
     // Strings
     static let kBackground = "background"
     static let errorMessageLoginScreenEmailNotValid = "Invalid Email"
@@ -13,14 +13,14 @@ struct RHConstants {
 
     // Storyboard / Xib
     static let kStoryboardMain = "Main"
-    static let kDashboardViewController = "RHDashboardViewController"
+    static let kDashboardViewController = "DashboardViewController"
     static let kHabitTableViewCell = "HabitTableViewCell"
-    static let kHabitDetailViewController = "RHHabitDetailViewController"
-    static let kSwitchWorkspaceViewController = "RHSwitchWorkspaceViewController"
+    static let kHabitDetailViewController = "HabitDetailViewController"
+    static let kSwitchWorkspaceViewController = "SwitchWorkspaceViewController"
     static let kHabitReminderTableViewCell = "HabitReminderTableViewCell"
     static let kHabitDetailToggleTableViewCell = "HabitDetailToggleTableViewCell"
     static let kHabitAddInfoTableViewCell = "HabitAddInfoTableViewCell"
-    static let kLoginViewController = "RHLoginViewController"
+    static let kLoginViewController = "LoginViewController"
 
     // Images / Assets
     static let kLogo = "logo"

--- a/Remote Habits/Common/Font+Color.swift
+++ b/Remote Habits/Common/Font+Color.swift
@@ -1,12 +1,12 @@
 import Foundation
 import UIKit
 
-struct RHFont {
+struct Font {
     static let SFProTextSemiBoldMedium = UIFont(name: "SFProText-Semibold", size: 17)
     static let AwesomeFontLarge = UIFont(name: "FontAwesome", size: 20)
 }
 
-enum RHColor {
+enum Color {
     static let LabelGray = UIColor(named: "LabelGray") ?? UIColor.gray
     static let LineGray = UIColor(named: "LineGray") ?? UIColor.gray
     static let SelectedLineGray = UIColor(named: "SelectedLineGray") ?? UIColor.gray
@@ -16,7 +16,7 @@ enum RHColor {
     static let TextDisabled = UIColor(named: "TextDisabled") ?? UIColor.gray
     static let LabelBlack = UIColor(named: "LabelBlack") ?? UIColor.black
     static let PrimaryBackground = UIColor(named: "PrimaryBackground") ?? UIColor.white
-    static let LabelLightGray = UIColor(named: "LabelLightGray") ?? RHColor.LabelGray
+    static let LabelLightGray = UIColor(named: "LabelLightGray") ?? Color.LabelGray
     static let MediumGray = UIColor(named: "MediumGray") ?? UIColor.gray
 }
 

--- a/Remote Habits/Extension/StorybordExtensions.swift
+++ b/Remote Habits/Extension/StorybordExtensions.swift
@@ -8,7 +8,7 @@ extension UIStoryboard {
         // the app is able to be viewed (meaning all ViewControllers were instantiated
         // successfully), then this code is safe. Using a force cast here is to avoid
         // the annoyance of deciding what to do when there is a developer bug.
-        UIStoryboard(name: RHConstants.kStoryboardMain, bundle: nil)
+        UIStoryboard(name: Constants.kStoryboardMain, bundle: nil)
             // swiftlint:disable:next force_cast
             .instantiateViewController(withIdentifier: identifier) as! VC
     }

--- a/Remote Habits/Model/DashboardData.swift
+++ b/Remote Habits/Model/DashboardData.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-enum habitRowType : Int {
+enum HabitRowType: Int {
     case hydration = 1
     case breaks = 2
     case focus = 3
@@ -8,11 +8,12 @@ enum habitRowType : Int {
     case workspaceInfo = 5
     case sdkInfo = 6
 }
+
 struct HabitHeadersInfo: Hashable {
     let headerTitle: String?
     let titleFontSize: Int?
     let titleFontName: String?
-    let rowType: [habitRowType]?
+    let rowType: [HabitRowType]?
 }
 
 struct SelectedHabitData: Encodable {

--- a/Remote Habits/Model/DashboardData.swift
+++ b/Remote Habits/Model/DashboardData.swift
@@ -1,10 +1,18 @@
 import Foundation
 
+enum habitRowType : Int {
+    case hydration = 1
+    case breaks = 2
+    case focus = 3
+    case user = 4
+    case workspaceInfo = 5
+    case sdkInfo = 6
+}
 struct HabitHeadersInfo: Hashable {
     let headerTitle: String?
     let titleFontSize: Int?
     let titleFontName: String?
-    let ids: [Int]?
+    let rowType: [habitRowType]?
 }
 
 struct SelectedHabitData: Encodable {
@@ -43,47 +51,4 @@ struct HabitsData {
     let habitDescription: String?
     let actionName: String?
     let actionType: ActionType?
-    // =======
-    // enum HabitElementType {
-//    case toggleSwitch
-//    case button
-    // }
-//
-    // enum HabitActionType {
-//    case logout
-//    case login
-//    case switchWorkspace
-//    case toggleSwitch
-    // }
-//
-    // struct HabitData {
-//    let icon: String?
-//    let title: String?
-//    let subTitle: String?
-//    let type: HabitElementType?
-//    var habitDetail: HabitDetail?
-    // }
-//
-    // struct HabitDetail {
-//    var isHabitEnabled: Bool?
-//    var frequency: Int?
-//    var startTime: String?
-//    var endTime: String?
-//    var description: String?
-//    var actionButtonValue: String?
-//    var actionType: HabitActionType?
-    // }
-//
-    // struct HabitHeadersInfo: Hashable {
-//    let headerTitle: String?
-//    let titleFontSize: Int?
-//    let titleFontName: String?
-    // }
-//
-    // struct SelectedHabitData: Encodable {
-//    let title: String?
-//    let frequency: Int?
-//    let startTime: String?
-//    let endTime: String?
-    // >>>>>>> main
 }

--- a/Remote Habits/SceneDelegate.swift
+++ b/Remote Habits/SceneDelegate.swift
@@ -21,11 +21,11 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
         // If previous user is not a guest login and credentials were used to login into the app
         if userManager.isLoggedIn {
-            let navigationController = UINavigationController(rootViewController: RHDashboardViewController
+            let navigationController = UINavigationController(rootViewController: DashboardViewController
                 .newInstance())
             window?.rootViewController = navigationController
         } else {
-            let navigationController = UINavigationController(rootViewController: RHLoginViewController.newInstance())
+            let navigationController = UINavigationController(rootViewController: LoginViewController.newInstance())
             window?.rootViewController = navigationController
         }
         window?.makeKeyAndVisible()

--- a/Remote Habits/Stub/StubData.swift
+++ b/Remote Habits/Stub/StubData.swift
@@ -85,7 +85,7 @@ class RemoteHabitsData {
         let sdkData = HabitsData(id: 6,
                                  icon: "phone",
                                  title: "SDK",
-                                 subtitle: RHConstants.mockSdkInfo,
+                                 subtitle: Constants.mockSdkInfo,
                                  type: ElementType.none,
                                  isEnabled: nil,
                                  frequency: nil,

--- a/Remote Habits/Stub/StubData.swift
+++ b/Remote Habits/Stub/StubData.swift
@@ -9,9 +9,9 @@ class RemoteHabitsData {
     func getHabitHeaders() -> [HabitHeadersInfo] {
         let title = isLoggedIn ? userManager.userName : "Guest"
         let sectionfirst = HabitHeadersInfo(headerTitle: "\(title ?? "Your")'s Habits", titleFontSize: 34,
-                                            titleFontName: "SFProDisplay-Bold", ids: [1, 2, 3])
+                                            titleFontName: "SFProDisplay-Bold", rowType: [.hydration, .breaks, .focus])
         let sectionsecond = HabitHeadersInfo(headerTitle: "Details", titleFontSize: 17,
-                                             titleFontName: "SFProDisplay-Bold", ids: [4, 5])
+                                             titleFontName: "SFProDisplay-Bold", rowType: [.user, .workspaceInfo])
 
         return [sectionfirst, sectionsecond]
     }

--- a/Remote Habits/View/Common/BaseViewController.swift
+++ b/Remote Habits/View/Common/BaseViewController.swift
@@ -5,7 +5,7 @@ enum ControllerSource {
     case habitdetail
 }
 
-class RHBaseViewController: UIViewController {
+class BaseViewController: UIViewController {
     var loaderView: UIView?
     let habitsDataManager = HabitDataManager()
     var trackerViewModel = DI.shared.trackerViewModel
@@ -18,14 +18,14 @@ class RHBaseViewController: UIViewController {
     // MARK: - Common Methods
 
     func addDefaultBackground() {
-        view.backgroundColor = RHColor.DefaultBackground
+        view.backgroundColor = Color.DefaultBackground
     }
 
     func addLoginBackground() {
         let imageBg =
             UIImageView(frame: CGRect(x: 0, y: 0, width: UIScreen.main.bounds.width,
                                       height: UIScreen.main.bounds.height))
-        imageBg.image = UIImage(named: RHConstants.kBackground)
+        imageBg.image = UIImage(named: Constants.kBackground)
         view.addSubview(imageBg)
         view.sendSubviewToBack(imageBg)
     }
@@ -47,7 +47,7 @@ class RHBaseViewController: UIViewController {
 
         // add image for loader background
         let imageBg = UIImageView(frame: CGRect(x: 0, y: 0, width: 80, height: 80))
-        imageBg.image = UIImage(named: RHConstants.kBackground)
+        imageBg.image = UIImage(named: Constants.kBackground)
         imageBg.setCornerRadius(.radius40)
         imageBg.layer.masksToBounds = true
 
@@ -79,7 +79,7 @@ class RHBaseViewController: UIViewController {
             navigationItem.setHidesBackButton(hideBack, animated: true)
         } else {
             let btnLeftOnBar: UIButton = .init()
-            btnLeftOnBar.setImage(UIImage(named: RHConstants.kBack), for: .normal)
+            btnLeftOnBar.setImage(UIImage(named: Constants.kBack), for: .normal)
             btnLeftOnBar.addTarget(self, action: #selector(goBack), for: .touchUpInside)
             btnLeftOnBar.frame = CGRect(x: 0, y: 0, width: 20, height: 20)
             let barButton = UIBarButtonItem(customView: btnLeftOnBar)
@@ -89,7 +89,7 @@ class RHBaseViewController: UIViewController {
             let headerView = UIView(frame: CGRect(x: 0, y: 0, width: UIScreen.main.bounds.width, height: 44))
             let imageView = UIImageView(frame: CGRect(x: headerView.center.x - 24, y: 0, width: 24, height: 24))
             imageView.contentMode = .scaleAspectFit
-            let image = UIImage(named: RHConstants.kLogo)
+            let image = UIImage(named: Constants.kLogo)
             imageView.image = image
             headerView.addSubview(imageView)
             navigationItem.titleView = headerView
@@ -99,8 +99,8 @@ class RHBaseViewController: UIViewController {
         if #available(iOS 13.0, *) {
             let navBarAppearance = UINavigationBarAppearance()
             navBarAppearance.configureWithOpaqueBackground()
-            navBarAppearance.titleTextAttributes = [.foregroundColor: titleColor ?? RHColor.LabelBlack]
-            navBarAppearance.backgroundColor = backgoundColor ?? RHColor.DefaultBackground
+            navBarAppearance.titleTextAttributes = [.foregroundColor: titleColor ?? Color.LabelBlack]
+            navBarAppearance.backgroundColor = backgoundColor ?? Color.DefaultBackground
 
             navigationController?.navigationBar.standardAppearance = navBarAppearance
             navigationController?.navigationBar.compactAppearance = navBarAppearance
@@ -136,7 +136,7 @@ class RHBaseViewController: UIViewController {
             trackerViewModel.trackHabitActivity(withName: activity, forHabit: selectedHabit)
         }
         if source == .habitdetail {
-            NotificationCenter.default.post(name: Notification.Name(RHConstants.kHabitsUpdatedIdentifier), object: nil)
+            NotificationCenter.default.post(name: Notification.Name(Constants.kHabitsUpdatedIdentifier), object: nil)
         }
     }
     /*

--- a/Remote Habits/View/Common/ToolbarUtil.swift
+++ b/Remote Habits/View/Common/ToolbarUtil.swift
@@ -9,7 +9,7 @@ class Toolbar: UIToolbar {
     // Standard tool bar with height 35
     func standardToolBar(_ withItems: [ToolBarButtonItem: Selector]) -> UIToolbar {
         let toolbar: UIToolbar =
-            .init(frame: CGRect(x: 0, y: 0, width: UIScreen.main.bounds.width, height: RHConstants.kToolBarHeight))
+            .init(frame: CGRect(x: 0, y: 0, width: UIScreen.main.bounds.width, height: Constants.kToolBarHeight))
         toolbar.barStyle = .default
         toolbar.sizeToFit()
         var barButtonItems = [UIBarButtonItem]()

--- a/Remote Habits/View/Customisation/CustomisedTableView.swift
+++ b/Remote Habits/View/Customisation/CustomisedTableView.swift
@@ -1,7 +1,7 @@
 import Foundation
 import UIKit
 
-class RHCustomisedTableView: UITableView {
+class CustomisedTableView: UITableView {
     override var adjustedContentInset: UIEdgeInsets {
         if frame.height > contentSize.height {
             let heightBottom =

--- a/Remote Habits/View/DashboardViewController.swift
+++ b/Remote Habits/View/DashboardViewController.swift
@@ -113,7 +113,7 @@ extension DashboardViewController: UITableViewDelegate {
 
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         if indexPath.section != 0 { return }
-        guard let id = dashboardHeaders[indexPath.section].ids?[indexPath.row],
+        guard let id = dashboardHeaders[indexPath.section].rowType?[indexPath.row].rawValue,
               let habitData = habitsDataManager.getHabit(forId: id)
         else {
             return
@@ -140,13 +140,13 @@ extension DashboardViewController: UITableViewDataSource {
     }
 
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        dashboardHeaders[section].ids?.count ?? 0
+        dashboardHeaders[section].rowType?.count ?? 0
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         guard let cell = tableView.dequeueReusableCell(withIdentifier: Constants.kHabitTableViewCell,
                                                        for: indexPath) as? HabitTableViewCell,
-            let id = dashboardHeaders[indexPath.section].ids?[indexPath.row],
+              let id = dashboardHeaders[indexPath.section].rowType?[indexPath.row].rawValue,
             let habitData = habitsDataManager.getHabit(forId: id)
         else {
             return UITableViewCell()

--- a/Remote Habits/View/DashboardViewController.swift
+++ b/Remote Habits/View/DashboardViewController.swift
@@ -1,8 +1,8 @@
 import UIKit
 
-class RHDashboardViewController: RHBaseViewController {
-    static func newInstance() -> RHDashboardViewController {
-        UIStoryboard.getViewController(identifier: RHConstants.kDashboardViewController)
+class DashboardViewController: BaseViewController {
+    static func newInstance() -> DashboardViewController {
+        UIStoryboard.getViewController(identifier: Constants.kDashboardViewController)
     }
 
     // MARK: - --OUTLETS--
@@ -22,7 +22,7 @@ class RHDashboardViewController: RHBaseViewController {
         super.viewDidLoad()
 
         dashboardHeaders = remoteHabitsData.getHabitHeaders()
-        configureNavigationBar(title: RHConstants.kEmptyValue, hideBack: true, showLogo: true)
+        configureNavigationBar(title: Constants.kEmptyValue, hideBack: true, showLogo: true)
         addNotifierObserver()
         addDefaultBackground()
         setupDashboardTableView()
@@ -37,7 +37,7 @@ class RHDashboardViewController: RHBaseViewController {
 
     func addNotifierObserver() {
         NotificationCenter.default.addObserver(self, selector: #selector(reloadHabitsData(notification:)),
-                                               name: Notification.Name(RHConstants.kHabitsUpdatedIdentifier),
+                                               name: Notification.Name(Constants.kHabitsUpdatedIdentifier),
                                                object: nil)
     }
 
@@ -46,8 +46,8 @@ class RHDashboardViewController: RHBaseViewController {
     }
 
     func setupDashboardTableView() {
-        dashboardTableView.register(UINib(nibName: RHConstants.kHabitTableViewCell, bundle: nil),
-                                    forCellReuseIdentifier: RHConstants.kHabitTableViewCell)
+        dashboardTableView.register(UINib(nibName: Constants.kHabitTableViewCell, bundle: nil),
+                                    forCellReuseIdentifier: Constants.kHabitTableViewCell)
         dashboardTableView.setAutomaticRowHeight(height: .defaultHeight)
         dashboardTableView.delegate = self
         dashboardTableView.dataSource = self
@@ -57,9 +57,9 @@ class RHDashboardViewController: RHBaseViewController {
 
     func route(to controller: String, withData: Habits? = nil) {
         switch controller {
-        case RHConstants.kHabitDetailViewController:
+        case Constants.kHabitDetailViewController:
             navigateToDashboardDetail(withData: withData)
-        case RHConstants.kSwitchWorkspaceViewController:
+        case Constants.kSwitchWorkspaceViewController:
             navigateToWorkspace()
         default:
             break
@@ -67,9 +67,9 @@ class RHDashboardViewController: RHBaseViewController {
     }
 
     func navigateToDashboardDetail(withData: Habits?) {
-        if let viewController = UIStoryboard(name: RHConstants.kStoryboardMain, bundle: nil)
-            .instantiateViewController(withIdentifier: RHConstants
-                .kHabitDetailViewController) as? RHHabitDetailViewController, let habitData = withData {
+        if let viewController = UIStoryboard(name: Constants.kStoryboardMain, bundle: nil)
+            .instantiateViewController(withIdentifier: Constants
+                .kHabitDetailViewController) as? HabitDetailViewController, let habitData = withData {
             viewController.habitDetailData = habitData
             let navigation = UINavigationController(rootViewController: viewController)
             present(navigation, animated: true, completion: nil)
@@ -77,9 +77,9 @@ class RHDashboardViewController: RHBaseViewController {
     }
 
     func navigateToWorkspace() {
-        if let viewController = UIStoryboard(name: RHConstants.kStoryboardMain, bundle: nil)
-            .instantiateViewController(withIdentifier: RHConstants
-                .kSwitchWorkspaceViewController) as? RHSwitchWorkspaceViewController {
+        if let viewController = UIStoryboard(name: Constants.kStoryboardMain, bundle: nil)
+            .instantiateViewController(withIdentifier: Constants
+                .kSwitchWorkspaceViewController) as? SwitchWorkspaceViewController {
             let navigation = UINavigationController(rootViewController: viewController)
             present(navigation, animated: true, completion: nil)
         }
@@ -88,7 +88,7 @@ class RHDashboardViewController: RHBaseViewController {
 
 // MARK: - --UITABLEVIEWDELEGATE--
 
-extension RHDashboardViewController: UITableViewDelegate {
+extension DashboardViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
         97.0
     }
@@ -105,7 +105,7 @@ extension RHDashboardViewController: UITableViewDelegate {
 
         label.text = headerData.headerTitle ?? ""
         label.font = UIFont(name: headerData.titleFontName ?? "", size: CGFloat(headerData.titleFontSize ?? 17))
-        label.textColor = RHColor.LabelBlack
+        label.textColor = Color.LabelBlack
         headerView.addSubview(label)
 
         return headerView
@@ -127,14 +127,14 @@ extension RHDashboardViewController: UITableViewDelegate {
                                                   .formatDateToString(inFormat: .time12Hour),
                                               id: Int(habitData.id),
                                               isEnabled: habitData.isEnabled)
-        updateHabit(forActivity: RHConstants.kHabitClicked, selectedHabit: selectedHabit, andSource: .habitdashboard)
-        route(to: RHConstants.kHabitDetailViewController, withData: habitData)
+        updateHabit(forActivity: Constants.kHabitClicked, selectedHabit: selectedHabit, andSource: .habitdashboard)
+        route(to: Constants.kHabitDetailViewController, withData: habitData)
     }
 }
 
 // MARK: - --UITABLEVIEWDATASOURCE--
 
-extension RHDashboardViewController: UITableViewDataSource {
+extension DashboardViewController: UITableViewDataSource {
     func numberOfSections(in tableView: UITableView) -> Int {
         dashboardHeaders.count
     }
@@ -144,7 +144,7 @@ extension RHDashboardViewController: UITableViewDataSource {
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        guard let cell = tableView.dequeueReusableCell(withIdentifier: RHConstants.kHabitTableViewCell,
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: Constants.kHabitTableViewCell,
                                                        for: indexPath) as? HabitTableViewCell,
             let id = dashboardHeaders[indexPath.section].ids?[indexPath.row],
             let habitData = habitsDataManager.getHabit(forId: id)
@@ -160,11 +160,11 @@ extension RHDashboardViewController: UITableViewDataSource {
     }
 }
 
-// MARK: - Protocol - RHDashboardActionHandler
+// MARK: - Protocol - DashboardActionHandler
 
-extension RHDashboardViewController: RHDashboardActionHandler {
+extension DashboardViewController: DashboardActionHandler {
     func toggleHabit(toValue isEnabled: Bool, habitData: SelectedHabitData) {
-        updateHabit(forActivity: isEnabled ? RHConstants.kHabitEnabled : RHConstants.kHabitDisabled,
+        updateHabit(forActivity: isEnabled ? Constants.kHabitEnabled : Constants.kHabitDisabled,
                     selectedHabit: habitData, andSource: .habitdashboard)
     }
 
@@ -173,7 +173,7 @@ extension RHDashboardViewController: RHDashboardActionHandler {
         if isSourceLogin {
             navigationController?.popToRootViewController(animated: true)
         } else {
-            navigationController?.setViewControllers([RHLoginViewController.newInstance()], animated: true)
+            navigationController?.setViewControllers([LoginViewController.newInstance()], animated: true)
         }
     }
 
@@ -182,6 +182,6 @@ extension RHDashboardViewController: RHDashboardActionHandler {
     }
 
     func switchWorkspace() {
-        route(to: RHConstants.kSwitchWorkspaceViewController)
+        route(to: Constants.kSwitchWorkspaceViewController)
     }
 }

--- a/Remote Habits/View/DashboardViewController.swift
+++ b/Remote Habits/View/DashboardViewController.swift
@@ -146,7 +146,7 @@ extension DashboardViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         guard let cell = tableView.dequeueReusableCell(withIdentifier: Constants.kHabitTableViewCell,
                                                        for: indexPath) as? HabitTableViewCell,
-              let id = dashboardHeaders[indexPath.section].rowType?[indexPath.row].rawValue,
+            let id = dashboardHeaders[indexPath.section].rowType?[indexPath.row].rawValue,
             let habitData = habitsDataManager.getHabit(forId: id)
         else {
             return UITableViewCell()

--- a/Remote Habits/View/HabitDetailViewController.swift
+++ b/Remote Habits/View/HabitDetailViewController.swift
@@ -1,13 +1,13 @@
 import UIKit
 
-class RHHabitDetailViewController: RHBaseViewController {
-    static func newInstance() -> RHHabitDetailViewController {
-        UIStoryboard.getViewController(identifier: RHConstants.kHabitDetailViewController)
+class HabitDetailViewController: BaseViewController {
+    static func newInstance() -> HabitDetailViewController {
+        UIStoryboard.getViewController(identifier: Constants.kHabitDetailViewController)
     }
 
     // MARK: - --OUTLETS--
 
-    @IBOutlet var habitDetailTableView: RHCustomisedTableView!
+    @IBOutlet var habitDetailTableView: CustomisedTableView!
     @IBOutlet var headerHeightConstraint: NSLayoutConstraint!
     @IBOutlet var reminderLabel: UILabel!
     @IBOutlet var habitLogo: UIImageView!
@@ -35,12 +35,12 @@ class RHHabitDetailViewController: RHBaseViewController {
         habitDetailTableView.dataSource = self
         habitDetailTableView.delegate = self
 
-        habitDetailTableView.register(UINib(nibName: RHConstants.kHabitReminderTableViewCell, bundle: nil),
-                                      forCellReuseIdentifier: RHConstants.kHabitReminderTableViewCell)
-        habitDetailTableView.register(UINib(nibName: RHConstants.kHabitDetailToggleTableViewCell, bundle: nil),
-                                      forCellReuseIdentifier: RHConstants.kHabitDetailToggleTableViewCell)
-        habitDetailTableView.register(UINib(nibName: RHConstants.kHabitAddInfoTableViewCell, bundle: nil),
-                                      forCellReuseIdentifier: RHConstants.kHabitAddInfoTableViewCell)
+        habitDetailTableView.register(UINib(nibName: Constants.kHabitReminderTableViewCell, bundle: nil),
+                                      forCellReuseIdentifier: Constants.kHabitReminderTableViewCell)
+        habitDetailTableView.register(UINib(nibName: Constants.kHabitDetailToggleTableViewCell, bundle: nil),
+                                      forCellReuseIdentifier: Constants.kHabitDetailToggleTableViewCell)
+        habitDetailTableView.register(UINib(nibName: Constants.kHabitAddInfoTableViewCell, bundle: nil),
+                                      forCellReuseIdentifier: Constants.kHabitAddInfoTableViewCell)
 
         habitDetailTableView.setAutomaticRowHeight(height: .height100)
         habitDetailTableView.setContentOffset(.zero, animated: false)
@@ -48,7 +48,7 @@ class RHHabitDetailViewController: RHBaseViewController {
 
     func setUpHeader() {
         reminderLabel.text = "Set reminder to \(habitDetailData?.title ?? "good remote habits")"
-        reminderLabel.textColor = RHColor.LabelLightGray
+        reminderLabel.textColor = Color.LabelLightGray
         if let logo = habitDetailData?.icon {
             habitLogo.image = UIImage(named: logo)
         }
@@ -57,14 +57,14 @@ class RHHabitDetailViewController: RHBaseViewController {
 
 // MARK: - --UITABLEVIEWDATASOURCE--
 
-extension RHHabitDetailViewController: UITableViewDataSource {
+extension HabitDetailViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         3
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         if indexPath.row == 0 || indexPath.row == 3 {
-            guard let cell = tableView.dequeueReusableCell(withIdentifier: RHConstants.kHabitDetailToggleTableViewCell,
+            guard let cell = tableView.dequeueReusableCell(withIdentifier: Constants.kHabitDetailToggleTableViewCell,
                                                            for: indexPath) as? HabitDetailToggleTableViewCell
             else {
                 return UITableViewCell()
@@ -74,7 +74,7 @@ extension RHHabitDetailViewController: UITableViewDataSource {
             cell.fillHabitsData()
             return cell
         } else if indexPath.row == 1 || indexPath.row == 4 {
-            guard let cell = tableView.dequeueReusableCell(withIdentifier: RHConstants.kHabitReminderTableViewCell,
+            guard let cell = tableView.dequeueReusableCell(withIdentifier: Constants.kHabitReminderTableViewCell,
                                                            for: indexPath) as? HabitReminderTableViewCell
             else {
                 return UITableViewCell()
@@ -84,7 +84,7 @@ extension RHHabitDetailViewController: UITableViewDataSource {
             cell.fillHabitDetailData()
             return cell
         } else if indexPath.row == 2 || indexPath.row == 5 {
-            guard let cell = tableView.dequeueReusableCell(withIdentifier: RHConstants.kHabitAddInfoTableViewCell,
+            guard let cell = tableView.dequeueReusableCell(withIdentifier: Constants.kHabitAddInfoTableViewCell,
                                                            for: indexPath) as? HabitAddInfoTableViewCell
             else {
                 return UITableViewCell()
@@ -98,11 +98,11 @@ extension RHHabitDetailViewController: UITableViewDataSource {
 
 // MARK: - --UITABLEVIEWDELEGATE--
 
-extension RHHabitDetailViewController: UITableViewDelegate {}
+extension HabitDetailViewController: UITableViewDelegate {}
 
 // MARK: - --UISCROLLVIEWDELEGATE--
 
-extension RHHabitDetailViewController: UIScrollViewDelegate {
+extension HabitDetailViewController: UIScrollViewDelegate {
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
         let offsetY: CGFloat = scrollView.contentOffset.y
         guard let headerViewHeightConstraint = headerHeightConstraint else { return }
@@ -119,9 +119,9 @@ extension RHHabitDetailViewController: UIScrollViewDelegate {
     }
 }
 
-extension RHHabitDetailViewController: RHDashboardDetailActionHandler {
+extension HabitDetailViewController: DashboardDetailActionHandler {
     func toggleHabit(toValue isEnabled: Bool) {
-        let activity = isEnabled ? RHConstants.kHabitEnabled : RHConstants.kHabitDisabled
+        let activity = isEnabled ? Constants.kHabitEnabled : Constants.kHabitDisabled
         let selectedHabit = SelectedHabitData(title: habitDetailData?.title,
                                               frequency: Int(habitDetailData?.frequency ?? 0),
                                               startTime: habitDetailData?.startTime?
@@ -134,7 +134,7 @@ extension RHHabitDetailViewController: RHDashboardDetailActionHandler {
     }
 }
 
-extension RHHabitDetailViewController: RHDashboardDetailTimeHandler {
+extension HabitDetailViewController: DashboardDetailTimeHandler {
     func updateTime(with selectedHabit: SelectedHabitData) {
         updateHabit(forActivity: nil, selectedHabit: selectedHabit, andSource: .habitdetail)
     }

--- a/Remote Habits/View/Handler/HabitDashboardProtocolHandler.swift
+++ b/Remote Habits/View/Handler/HabitDashboardProtocolHandler.swift
@@ -1,16 +1,16 @@
 import Foundation
 
-protocol RHDashboardActionHandler: AnyObject {
+protocol DashboardActionHandler: AnyObject {
     func logoutUser()
     func loginUser()
     func switchWorkspace()
     func toggleHabit(toValue isEnabled: Bool, habitData: SelectedHabitData)
 }
 
-protocol RHDashboardDetailActionHandler {
+protocol DashboardDetailActionHandler {
     func toggleHabit(toValue isEnabled: Bool)
 }
 
-protocol RHDashboardDetailTimeHandler {
+protocol DashboardDetailTimeHandler {
     func updateTime(with: SelectedHabitData)
 }

--- a/Remote Habits/View/LoginViewController.swift
+++ b/Remote Habits/View/LoginViewController.swift
@@ -1,11 +1,11 @@
 import SkyFloatingLabelTextField
 import UIKit
 
-class RHLoginViewController: RHBaseViewController {
+class LoginViewController: BaseViewController {
     // MARK: - --OUTLETS--
 
-    static func newInstance() -> RHLoginViewController {
-        UIStoryboard.getViewController(identifier: RHConstants.kLoginViewController)
+    static func newInstance() -> LoginViewController {
+        UIStoryboard.getViewController(identifier: Constants.kLoginViewController)
     }
 
     @IBOutlet var userNameInput: SkyFloatingLabelTextFieldWithIcon!
@@ -53,15 +53,15 @@ class RHLoginViewController: RHBaseViewController {
     func setupButtons() {
         // Buttons
         loginButton.isEnabled = false
-        loginButton.titleLabel?.font = RHFont.SFProTextSemiBoldMedium
-        loginButton.setTitleColor(RHColor.TextDisabled, for: .disabled)
+        loginButton.titleLabel?.font = Font.SFProTextSemiBoldMedium
+        loginButton.setTitleColor(Color.TextDisabled, for: .disabled)
         loginButton.setTitleColor(UIColor.white, for: .normal)
         loginButton.setCornerRadius(.radius24)
         loginButtonState()
     }
 
     func loginButtonState() {
-        loginButton.backgroundColor = loginButton.isEnabled ? RHColor.ButtonEnabled : RHColor.ButtonDisabled
+        loginButton.backgroundColor = loginButton.isEnabled ? Color.ButtonEnabled : Color.ButtonDisabled
     }
 
     func setUpTextFields() {
@@ -76,13 +76,13 @@ class RHLoginViewController: RHBaseViewController {
                 break
             }
 
-            field.placeholderColor = RHColor.LabelGray
+            field.placeholderColor = Color.LabelGray
             field.textColor = UIColor.black
-            field.iconFont = RHFont.AwesomeFontLarge
-            field.tintColor = RHColor.LabelGray
-            field.lineColor = RHColor.LineGray
-            field.selectedTitleColor = RHColor.LabelGray
-            field.selectedLineColor = RHColor.SelectedLineGray
+            field.iconFont = Font.AwesomeFontLarge
+            field.tintColor = Color.LabelGray
+            field.lineColor = Color.LineGray
+            field.selectedTitleColor = Color.LabelGray
+            field.selectedLineColor = Color.SelectedLineGray
             field.delegate = self
         }
     }
@@ -114,11 +114,11 @@ class RHLoginViewController: RHBaseViewController {
     }
 
     func routeToDashboard() {
-        userNameInput.text = RHConstants.kEmptyValue
-        emailInput.text = RHConstants.kEmptyValue
+        userNameInput.text = Constants.kEmptyValue
+        emailInput.text = Constants.kEmptyValue
         loginButton.isEnabled = false
         loginButtonState()
-        let viewController = RHDashboardViewController.newInstance()
+        let viewController = DashboardViewController.newInstance()
         viewController.isSourceLogin = true
         navigationController?.pushViewController(viewController, animated: true)
     }
@@ -136,9 +136,9 @@ class RHLoginViewController: RHBaseViewController {
         if let floatingLabelTextField = sender as? SkyFloatingLabelTextFieldWithIcon {
             if let text = floatingLabelTextField.text {
                 if !validateEmail(text) {
-                    floatingLabelTextField.errorMessage = RHConstants.errorMessageLoginScreenEmailNotValid
+                    floatingLabelTextField.errorMessage = Constants.errorMessageLoginScreenEmailNotValid
                 } else {
-                    floatingLabelTextField.errorMessage = RHConstants.kEmptyValue
+                    floatingLabelTextField.errorMessage = Constants.kEmptyValue
                     floatingLabelTextField.text = floatingLabelTextField.text
                 }
                 if validateName(userNameInput), validateEmail(text) {
@@ -153,7 +153,7 @@ class RHLoginViewController: RHBaseViewController {
 
     @IBAction func nameDidChange(_ sender: Any) {
         if let field = sender as? UITextField {
-            if validateName(field), validateEmail(emailInput.text ?? RHConstants.kEmptyValue) {
+            if validateName(field), validateEmail(emailInput.text ?? Constants.kEmptyValue) {
                 loginButton.isEnabled = true
             } else {
                 loginButton.isEnabled = false
@@ -166,12 +166,12 @@ class RHLoginViewController: RHBaseViewController {
         guard let eId = emailInput.text, let username = userNameInput.text else {
             return
         }
-        validateCredentials(email: eId, pwd: RHConstants.kDefaultPassword, firstName: username, isGenRandom: false)
+        validateCredentials(email: eId, pwd: Constants.kDefaultPassword, firstName: username, isGenRandom: false)
     }
 
     @IBAction func guestButtonTapped(_ sender: UIButton) {
-        validateCredentials(email: RHConstants.kRandomEId, pwd: RHConstants.kDefaultPassword,
-                            firstName: RHConstants.kRandomUsername, isGenRandom: true)
+        validateCredentials(email: Constants.kRandomEId, pwd: Constants.kDefaultPassword,
+                            firstName: Constants.kRandomUsername, isGenRandom: true)
     }
 
     func validateCredentials(email: String, pwd: String, firstName: String, isGenRandom: Bool) {
@@ -193,11 +193,11 @@ class RHLoginViewController: RHBaseViewController {
 
 // MARK: - UITextFieldDelegate
 
-extension RHLoginViewController: UITextFieldDelegate {
+extension LoginViewController: UITextFieldDelegate {
     func textFieldDidEndEditing(_ textField: UITextField) {
         if textField == emailInput, textField.trimTextWithWhiteSpaces {
             if let field = textField as? SkyFloatingLabelTextFieldWithIcon {
-                field.errorMessage = RHConstants.kEmptyValue
+                field.errorMessage = Constants.kEmptyValue
             }
         }
     }

--- a/Remote Habits/View/SwitchWorkspaceViewController.swift
+++ b/Remote Habits/View/SwitchWorkspaceViewController.swift
@@ -1,9 +1,9 @@
 import SkyFloatingLabelTextField
 import UIKit
 
-class RHSwitchWorkspaceViewController: RHBaseViewController, UITextFieldDelegate {
-    static func newInstance() -> RHSwitchWorkspaceViewController {
-        UIStoryboard.getViewController(identifier: RHConstants.kSwitchWorkspaceViewController)
+class SwitchWorkspaceViewController: BaseViewController, UITextFieldDelegate {
+    static func newInstance() -> SwitchWorkspaceViewController {
+        UIStoryboard.getViewController(identifier: Constants.kSwitchWorkspaceViewController)
     }
 
     // MARK: - --OUTLETS--
@@ -25,7 +25,7 @@ class RHSwitchWorkspaceViewController: RHBaseViewController, UITextFieldDelegate
         super.viewDidLoad()
 
         // Do any additional setup after loading the view.
-        configureNavigationBar(title: RHConstants.kCIO, hideBack: false, showLogo: false)
+        configureNavigationBar(title: Constants.kCIO, hideBack: false, showLogo: false)
         addDefaultBackground()
         setUpMainView()
         setUpWorkspaceButton()
@@ -37,20 +37,20 @@ class RHSwitchWorkspaceViewController: RHBaseViewController, UITextFieldDelegate
 
     func setUpMainView() {
         mainView.setCornerRadius(.radius13)
-        mainView.backgroundColor = RHColor.PrimaryBackground
+        mainView.backgroundColor = Color.PrimaryBackground
     }
 
     func setUpWorkspaceButton() {
         switchWorkspaceButton.isEnabled = false
-        switchWorkspaceButton.titleLabel?.font = RHFont.SFProTextSemiBoldMedium
-        switchWorkspaceButton.setTitleColor(RHColor.TextDisabled, for: .disabled)
+        switchWorkspaceButton.titleLabel?.font = Font.SFProTextSemiBoldMedium
+        switchWorkspaceButton.setTitleColor(Color.TextDisabled, for: .disabled)
         switchWorkspaceButton.setTitleColor(UIColor.white, for: .normal)
         switchWorkspaceButton.setCornerRadius(.radius24)
         workspaceButtonState()
     }
 
     func workspaceButtonState() {
-        switchWorkspaceButton.backgroundColor = switchWorkspaceButton.isEnabled ? RHColor.ButtonEnabled : RHColor
+        switchWorkspaceButton.backgroundColor = switchWorkspaceButton.isEnabled ? Color.ButtonEnabled : Color
             .ButtonDisabled
     }
 
@@ -62,12 +62,12 @@ class RHSwitchWorkspaceViewController: RHBaseViewController, UITextFieldDelegate
         let textFields = [siteIdInput, apiKeyInput]
         for field in textFields {
             field?.errorColor = UIColor.red
-            field?.tintColor = RHColor.LabelGray
-            field?.lineColor = RHColor.LineGray
-            field?.selectedTitleColor = RHColor.LabelLightGray
-            field?.selectedLineColor = RHColor.SelectedLineGray
-            field?.placeholderColor = RHColor.LabelLightGray
-            field?.textColor = RHColor.LabelBlack
+            field?.tintColor = Color.LabelGray
+            field?.lineColor = Color.LineGray
+            field?.selectedTitleColor = Color.LabelLightGray
+            field?.selectedLineColor = Color.SelectedLineGray
+            field?.placeholderColor = Color.LabelLightGray
+            field?.textColor = Color.LabelBlack
             field?.delegate = self
         }
     }
@@ -78,10 +78,10 @@ class RHSwitchWorkspaceViewController: RHBaseViewController, UITextFieldDelegate
         if let floatingLabelTextField = sender as? SkyFloatingLabelTextField {
             if let text = floatingLabelTextField.text {
                 if !validateInput(with: text) {
-                    let errorSuffix = floatingLabelTextField.placeholder ?? RHConstants.kValue
-                    floatingLabelTextField.errorMessage = "\(RHConstants.kInvalid) \(errorSuffix)"
+                    let errorSuffix = floatingLabelTextField.placeholder ?? Constants.kValue
+                    floatingLabelTextField.errorMessage = "\(Constants.kInvalid) \(errorSuffix)"
                 } else {
-                    floatingLabelTextField.errorMessage = RHConstants.kEmptyValue
+                    floatingLabelTextField.errorMessage = Constants.kEmptyValue
                 }
 
                 if validateInput(with: otherValue), validateInput(with: text) {
@@ -96,7 +96,7 @@ class RHSwitchWorkspaceViewController: RHBaseViewController, UITextFieldDelegate
     }
 
     func validateInput(with text: String) -> Bool {
-        text.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines) != RHConstants.kEmptyValue
+        text.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines) != Constants.kEmptyValue
     }
 
     /*
@@ -111,7 +111,7 @@ class RHSwitchWorkspaceViewController: RHBaseViewController, UITextFieldDelegate
     func routeToLogin() {
         if let navController = parent as? UINavigationController,
            let presenter = navController.presentingViewController as? UINavigationController {
-            presenter.setViewControllers([RHLoginViewController.newInstance()], animated: true)
+            presenter.setViewControllers([LoginViewController.newInstance()], animated: true)
             dismiss(animated: true, completion: nil)
         }
     }
@@ -124,11 +124,11 @@ class RHSwitchWorkspaceViewController: RHBaseViewController, UITextFieldDelegate
     // MARK: - --ACTIONS--
 
     @IBAction func siteIdValueChanged(_ sender: Any) {
-        didValueChange(sender, otherValue: apiKeyInput.text ?? RHConstants.kEmptyValue)
+        didValueChange(sender, otherValue: apiKeyInput.text ?? Constants.kEmptyValue)
     }
 
     @IBAction func apiKeyValueChanged(_ sender: Any) {
-        didValueChange(sender, otherValue: siteIdInput.text ?? RHConstants.kEmptyValue)
+        didValueChange(sender, otherValue: siteIdInput.text ?? Constants.kEmptyValue)
     }
 
     @IBAction func switchWorkspaceButtonTapped(_ sender: UIButton) {

--- a/Remote Habits/View/Xib/HabitDashboard/HabitTableViewCell.swift
+++ b/Remote Habits/View/Xib/HabitDashboard/HabitTableViewCell.swift
@@ -10,15 +10,15 @@ class HabitTableViewCell: UITableViewCell {
     var actionType: ActionType?
     var habitData: Habits?
 
-    weak var actionDelegate: RHDashboardActionHandler?
+    weak var actionDelegate: DashboardActionHandler?
 
     override func awakeFromNib() {
         super.awakeFromNib()
         // Initialization code
 
-        mainCellView.backgroundColor = RHColor.PrimaryBackground
-        habitTitle.textColor = RHColor.LabelBlack
-        habitSubTitle.textColor = RHColor.LabelLightGray
+        mainCellView.backgroundColor = Color.PrimaryBackground
+        habitTitle.textColor = Color.LabelBlack
+        habitSubTitle.textColor = Color.LabelLightGray
     }
 
     override func setSelected(_ selected: Bool, animated: Bool) {
@@ -33,7 +33,7 @@ class HabitTableViewCell: UITableViewCell {
             return
         }
 
-        habitIcon.image = UIImage(named: habitData.icon ?? RHConstants.kLogo)
+        habitIcon.image = UIImage(named: habitData.icon ?? Constants.kLogo)
         habitTitle.text = habitData.title
         habitSubTitle.text = habitData.subtitle
         actionType = habitData.actionType
@@ -49,7 +49,7 @@ class HabitTableViewCell: UITableViewCell {
             actionButton.isEnabled = habitData.isEnabled
             actionButton.setTitle(habitData.actionName, for: .normal)
         case .none:
-            actionButton.setTitle(RHConstants.kEmptyValue, for: .normal)
+            actionButton.setTitle(Constants.kEmptyValue, for: .normal)
             habitSwitch.isHidden = true
             actionButton.isHidden = true
         }

--- a/Remote Habits/View/Xib/HabitDetail/HabitAddInfoTableViewCell.swift
+++ b/Remote Habits/View/Xib/HabitDetail/HabitAddInfoTableViewCell.swift
@@ -7,8 +7,8 @@ class HabitAddInfoTableViewCell: UITableViewCell {
         super.awakeFromNib()
         // Initialization code
         mainCellView.setCornerRadius(.radius13)
-        mainCellView.backgroundColor = RHColor.PrimaryBackground
-        descriptionLabel.textColor = RHColor.LabelLightGray
+        mainCellView.backgroundColor = Color.PrimaryBackground
+        descriptionLabel.textColor = Color.LabelLightGray
         selectionStyle = .none
     }
 

--- a/Remote Habits/View/Xib/HabitDetail/HabitDetailToggleTableViewCell.swift
+++ b/Remote Habits/View/Xib/HabitDetail/HabitDetailToggleTableViewCell.swift
@@ -4,14 +4,14 @@ class HabitDetailToggleTableViewCell: UITableViewCell {
     @IBOutlet var habitSwitch: UISwitch!
     @IBOutlet var habitTitle: UILabel!
     @IBOutlet var mainCellView: UIView!
-    var actionHandler: RHDashboardDetailActionHandler?
+    var actionHandler: DashboardDetailActionHandler?
     var habitData: Habits?
 
     override func awakeFromNib() {
         super.awakeFromNib()
         // Initialization code
         mainCellView.setCornerRadius(.radius13)
-        mainCellView.backgroundColor = RHColor.PrimaryBackground
+        mainCellView.backgroundColor = Color.PrimaryBackground
         selectionStyle = .none
     }
 

--- a/Remote Habits/View/Xib/HabitDetail/HabitReminderTableViewCell.swift
+++ b/Remote Habits/View/Xib/HabitDetail/HabitReminderTableViewCell.swift
@@ -11,7 +11,7 @@ class HabitReminderTableViewCell: UITableViewCell, UITextFieldDelegate {
     @IBOutlet var mainCellView: UIView!
 
     var habitData: Habits?
-    var actionHandler: RHDashboardDetailTimeHandler?
+    var actionHandler: DashboardDetailTimeHandler?
     override func awakeFromNib() {
         super.awakeFromNib()
         // Initialization code
@@ -36,14 +36,14 @@ class HabitReminderTableViewCell: UITableViewCell, UITextFieldDelegate {
 
     func setUpCellView() {
         mainCellView.setCornerRadius(.radius13)
-        mainCellView.backgroundColor = RHColor.PrimaryBackground
-        frequencyLabel.textColor = RHColor.LabelLightGray
-        toLabel.textColor = RHColor.LabelLightGray
-        fromLabel.textColor = RHColor.LabelLightGray
-        fromTimeText.backgroundColor = RHColor.MediumGray
-        toTimeText.backgroundColor = RHColor.MediumGray
-        fromTimeText.textColor = RHColor.LabelLightGray
-        toTimeText.textColor = RHColor.LabelLightGray
+        mainCellView.backgroundColor = Color.PrimaryBackground
+        frequencyLabel.textColor = Color.LabelLightGray
+        toLabel.textColor = Color.LabelLightGray
+        fromLabel.textColor = Color.LabelLightGray
+        fromTimeText.backgroundColor = Color.MediumGray
+        toTimeText.backgroundColor = Color.MediumGray
+        fromTimeText.textColor = Color.LabelLightGray
+        toTimeText.textColor = Color.LabelLightGray
         selectionStyle = .none
     }
 


### PR DESCRIPTION
**This PR Contains :**

- Few file names in remote habits app started with prefix RH which was not aligned with the former remote habits app, hence removed prefix RH from file name.
> **Example :**
> RHLoginViewController.swift is now LoginViewController.swift

- Using enum for habit row type instead of integers [PR suggestion here](https://github.com/customerio/RemoteHabits-iOS/pull/42#discussion_r777708342)

