### PR TITLE
ci: modify names of test groups

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -93,7 +93,7 @@ platform :ios do
     new_app_version = values[:version] # default 
     is_main_build = new_app_version != nil && new_app_version != ""
     release_notes = ["app: Remote Habits iOS"]
-    groups = ['development'] # default - always send to these groups. 
+    groups = ['all-builds'] # default - always send to these groups. 
 
     github = GitHub.new(JSON.parse(ENV["GITHUB_CONTEXT"])) # context is a JSON string 
     new_build_number = github.commit_hash
@@ -101,7 +101,7 @@ platform :ios do
     if is_main_build
       UI.message("Deploying a main build of app. Version: #{new_app_version}")
 
-      groups.append("main-builds")       
+      groups.append("stable-builds")       
 
       release_notes.append(
         "build type: main",
@@ -117,7 +117,6 @@ platform :ios do
       if github.is_pull_request
         UI.message("I see this is a pull request. Build metadata will include helpful PR info.")
 
-        groups.append("QA") 
         new_app_version = "pr.#{github.pr_number}"
 
         release_notes.append(
@@ -154,7 +153,7 @@ platform :ios do
 
     UI.important("Release notes:\n#{release_notes}")
     UI.important("New app version: #{new_app_version}")
-    UI.important("App testing groups: #{groups}")
+    UI.important("Firebase App testing groups: #{groups}")
 
     set_info_plist_value(path: "./Remote Habits/Info.plist", key: "CFBundleVersion", value: new_build_number) # make sure unique build number to avoid clashing
     set_info_plist_value(path: "./Remote Habits/Info.plist", key: "CFBundleShortVersionString", value: new_app_version)


### PR DESCRIPTION
The CI server makes builds of this app and sends to internal *groups* of testers so we can test the app/SDK. 

We are simplifying the testing groups that we use from 3 groups to 2. This PR simply changes the CI server to deploy to these new groups. 
