### PR TITLE
feat: add support for screen tracking in remote habits

### DIFF
--- a/Remote Habits/AppDelegate.swift
+++ b/Remote Habits/AppDelegate.swift
@@ -25,8 +25,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             // This app is used internally for QA testing the Customer.io SDK. Therefore, we set the log level.
             // However, you probably don't need to modify it as the default will be useful for you.
             $0.logLevel = .debug
+            // Enabling `autoTrackScreenViews` will automatically track the screen and generate events as users visit them
+            $0.autoTrackScreenViews = true
+            
         }
-
         // Step 2: To display rich push notification
         UNUserNotificationCenter.current().delegate = self
 

--- a/Remote Habits/AppDelegate.swift
+++ b/Remote Habits/AppDelegate.swift
@@ -25,9 +25,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             // This app is used internally for QA testing the Customer.io SDK. Therefore, we set the log level.
             // However, you probably don't need to modify it as the default will be useful for you.
             $0.logLevel = .debug
-            // Enabling `autoTrackScreenViews` will automatically track the screen and generate events as users visit them
+            // Enabling `autoTrackScreenViews` will automatically track
+            // the screen and generate events as users visit them
             $0.autoTrackScreenViews = true
-            
         }
         // Step 2: To display rich push notification
         UNUserNotificationCenter.current().delegate = self


### PR DESCRIPTION
[Add support for screen tracking in remote habits](https://github.com/customerio/RemoteHabits-iOS/issues/49)

Screen tracking is a configurable property in Customer.io SDK. This PR has `autoTrackScreenViews` property enabled which will automatically track the screen and generate events as users visit them. All the events tracked will be pushed to the workspace and can be checked in activity logs.