### PR TITLE
ci: setup manually building app

### DIFF
--- a/.github/actions/prepare-for-app-build.yml
+++ b/.github/actions/prepare-for-app-build.yml
@@ -1,0 +1,31 @@
+# Boilerplate github action code to setup CI environment for building and deploying app. 
+# use in github action like:
+# - name: Setup environment for building and releasing app 
+#   uses: ./.github/actions/prepare-for-app-build.yml
+name: 'Prepare for building and releasing app'
+description: 'Do setup steps to setup the CI environment to be able to successfully build and deploy the app.'
+runs:
+  using: "composite"
+  steps:
+    - name: Setup Ruby to run Fastlane 
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 2.7.2
+        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+    - name: Prepare app for building and deploying 
+      shell: bash 
+      run: |
+        echo "${{ secrets.GOOGLE_SERVICES_BASE64 }}" | base64 -d > "Remote Habits/GoogleService-Info.plist"
+        echo "${{ secrets.ENV_FILE_B64 }}" | base64 -d > "Remote Habits/Env.swift"
+        echo "${{ secrets.FIREBASE_APP_DISTRIBUTION_GOOGLE_AUTH }}" | base64 -d > firebase_appdistribution_service_account.json
+        echo "${{ secrets.MATCH_GOOGLE_CLOUD_KEYS_B64 }}" | base64 -d > gc_keys.json
+      env:
+        GOOGLE_SERVICES_BASE64: "${{ secrets.GOOGLE_SERVICES_BASE64 }}"
+        ENV_FILE_B64: "${{ secrets.ENV_FILE_B64 }}"
+        FIREBASE_APP_DISTRIBUTION_GOOGLE_AUTH: ${{ secrets.FIREBASE_APP_DISTRIBUTION_GOOGLE_AUTH }}
+        MATCH_GOOGLE_CLOUD_KEYS_B64: ${{ secrets.MATCH_GOOGLE_CLOUD_KEYS_B64 }}  
+    - name: Install Fastlane 
+      uses: maierj/fastlane-action@v2.0.1
+      with:
+        lane: 'list' # give action a lane that doesn't perform an action to get fastlane installed on machine to use later. 
+        skip-tracking: true

--- a/.github/actions/prepare-for-app-build/action.yml
+++ b/.github/actions/prepare-for-app-build/action.yml
@@ -1,7 +1,7 @@
 # Boilerplate github action code to setup CI environment for building and deploying app. 
 # use in github action like:
 # - name: Setup environment for building and releasing app 
-#   uses: ./.github/actions/prepare-for-app-build.yml
+#   uses: ./.github/actions/prepare-for-app-build
 name: 'Prepare for building and releasing app'
 description: 'Do setup steps to setup the CI environment to be able to successfully build and deploy the app.'
 runs:

--- a/.github/actions/prepare-for-app-build/action.yml
+++ b/.github/actions/prepare-for-app-build/action.yml
@@ -2,8 +2,26 @@
 # use in github action like:
 # - name: Setup environment for building and releasing app 
 #   uses: ./.github/actions/prepare-for-app-build
+#   env:
+#     GOOGLE_SERVICES_BASE64: "${{ secrets.GOOGLE_SERVICES_BASE64 }}"
+#     ENV_FILE_B64: "${{ secrets.ENV_FILE_B64 }}"
+#     FIREBASE_APP_DISTRIBUTION_GOOGLE_AUTH: ${{ secrets.FIREBASE_APP_DISTRIBUTION_GOOGLE_AUTH }}
+#     MATCH_GOOGLE_CLOUD_KEYS_B64: ${{ secrets.MATCH_GOOGLE_CLOUD_KEYS_B64 }}  
 name: 'Prepare for building and releasing app'
 description: 'Do setup steps to setup the CI environment to be able to successfully build and deploy the app.'
+inputs:
+  GOOGLE_SERVICES_BASE64: 
+    description: 'GOOGLE_SERVICES_BASE64 from secrets'
+    required: true
+  ENV_FILE_B64: 
+    description: 'ENV_FILE_B64 from secrets'
+    required: true
+  FIREBASE_APP_DISTRIBUTION_GOOGLE_AUTH: 
+    description: 'FIREBASE_APP_DISTRIBUTION_GOOGLE_AUTH from secrets'
+    required: true
+  MATCH_GOOGLE_CLOUD_KEYS_B64:
+    description: 'MATCH_GOOGLE_CLOUD_KEYS_B64 from secrets'
+    required: true
 runs:
   using: "composite"
   steps:
@@ -15,15 +33,10 @@ runs:
     - name: Prepare app for building and deploying 
       shell: bash 
       run: |
-        echo "${{ secrets.GOOGLE_SERVICES_BASE64 }}" | base64 -d > "Remote Habits/GoogleService-Info.plist"
-        echo "${{ secrets.ENV_FILE_B64 }}" | base64 -d > "Remote Habits/Env.swift"
-        echo "${{ secrets.FIREBASE_APP_DISTRIBUTION_GOOGLE_AUTH }}" | base64 -d > firebase_appdistribution_service_account.json
-        echo "${{ secrets.MATCH_GOOGLE_CLOUD_KEYS_B64 }}" | base64 -d > gc_keys.json
-      env:
-        GOOGLE_SERVICES_BASE64: "${{ secrets.GOOGLE_SERVICES_BASE64 }}"
-        ENV_FILE_B64: "${{ secrets.ENV_FILE_B64 }}"
-        FIREBASE_APP_DISTRIBUTION_GOOGLE_AUTH: ${{ secrets.FIREBASE_APP_DISTRIBUTION_GOOGLE_AUTH }}
-        MATCH_GOOGLE_CLOUD_KEYS_B64: ${{ secrets.MATCH_GOOGLE_CLOUD_KEYS_B64 }}  
+        echo "${{ inputs.GOOGLE_SERVICES_BASE64 }}" | base64 -d > "Remote Habits/GoogleService-Info.plist"
+        echo "${{ inputs.ENV_FILE_B64 }}" | base64 -d > "Remote Habits/Env.swift"
+        echo "${{ inputs.FIREBASE_APP_DISTRIBUTION_GOOGLE_AUTH }}" | base64 -d > firebase_appdistribution_service_account.json
+        echo "${{ inputs.MATCH_GOOGLE_CLOUD_KEYS_B64 }}" | base64 -d > gc_keys.json
     - name: Install Fastlane 
       uses: maierj/fastlane-action@v2.0.1
       with:

--- a/.github/actions/prepare-for-app-build/action.yml
+++ b/.github/actions/prepare-for-app-build/action.yml
@@ -2,7 +2,7 @@
 # use in github action like:
 # - name: Setup environment for building and releasing app 
 #   uses: ./.github/actions/prepare-for-app-build
-#   env:
+#   with:
 #     GOOGLE_SERVICES_BASE64: "${{ secrets.GOOGLE_SERVICES_BASE64 }}"
 #     ENV_FILE_B64: "${{ secrets.ENV_FILE_B64 }}"
 #     FIREBASE_APP_DISTRIBUTION_GOOGLE_AUTH: ${{ secrets.FIREBASE_APP_DISTRIBUTION_GOOGLE_AUTH }}

--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -16,7 +16,12 @@ jobs:
       - uses: actions/checkout@v2
       - name: Setup environment for building and releasing app 
         uses: ./.github/actions/prepare-for-app-build
-      
+        env:
+          GOOGLE_SERVICES_BASE64: "${{ secrets.GOOGLE_SERVICES_BASE64 }}"
+          ENV_FILE_B64: "${{ secrets.ENV_FILE_B64 }}"
+          FIREBASE_APP_DISTRIBUTION_GOOGLE_AUTH: ${{ secrets.FIREBASE_APP_DISTRIBUTION_GOOGLE_AUTH }}
+          MATCH_GOOGLE_CLOUD_KEYS_B64: ${{ secrets.MATCH_GOOGLE_CLOUD_KEYS_B64 }}          
+            
       # Perform git related tasks inside of semantic-release because `git config user...` is already setup. It's easier to run commands in there with exec plugin.
       - name: Deploy app via semantic release 
         uses: cycjimmy/semantic-release-action@v2

--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -6,7 +6,7 @@ on:
 
 env:
   XCODE_VERSION: "13.0"
-  GITHUB_CONTEXT: ${{ toJSON(github) }}
+  GITHUB_CONTEXT: ${{ toJSON(github) }} # used by fastlane for deploying app 
 
 jobs:
   deploy-app:
@@ -14,41 +14,19 @@ jobs:
     runs-on: macos-11
     steps:
       - uses: actions/checkout@v2
-      - name: Setup Ruby to run Fastlane 
-        uses: ruby/setup-ruby@v1 
-        with:
-          ruby-version: 2.7.2
-          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
-      - name: Prepare app for building and deploying 
-        run: |
-          echo "${{ secrets.GOOGLE_SERVICES_BASE64 }}" | base64 -d > "Remote Habits/GoogleService-Info.plist"
-          echo "${{ secrets.ENV_FILE_B64 }}" | base64 -d > "Remote Habits/Env.swift"
-          echo "${{ secrets.FIREBASE_APP_DISTRIBUTION_GOOGLE_AUTH }}" | base64 -d > firebase_appdistribution_service_account.json
-          echo "${{ secrets.MATCH_GOOGLE_CLOUD_KEYS_B64 }}" | base64 -d > gc_keys.json
-        env:
-          GOOGLE_SERVICES_BASE64: "${{ secrets.GOOGLE_SERVICES_BASE64 }}"
-          ENV_FILE_B64: "${{ secrets.ENV_FILE_B64 }}"
-          FIREBASE_APP_DISTRIBUTION_GOOGLE_AUTH: ${{ secrets.FIREBASE_APP_DISTRIBUTION_GOOGLE_AUTH }}
-          MATCH_GOOGLE_CLOUD_KEYS_B64: ${{ secrets.MATCH_GOOGLE_CLOUD_KEYS_B64 }}
-      - name: Setup Fastlane 
-        uses: maierj/fastlane-action@v2.0.1
-        with:
-          lane: 'list' # give action a lane that doesn't perform an action to get fastlane installed on machine to use later. 
-          skip-tracking: true
+      - name: Setup environment for building and releasing app 
+        uses: ./.github/actions/prepare-for-app-build.yml
       
       # Perform git related tasks inside of semantic-release because `git config user...` is already setup. It's easier to run commands in there with exec plugin.
       - name: Deploy app via semantic release 
         uses: cycjimmy/semantic-release-action@v2
         with: 
           # version numbers below can be in many forms: M, M.m, M.m.p
-          semantic_version: 17
+          semantic_version: 18
           extra_plugins: |
-            @semantic-release/commit-analyzer@8
-            @semantic-release/release-notes-generator@9
-            @semantic-release/changelog@5
-            @semantic-release/git@9
-            @semantic-release/github@7
-            @semantic-release/exec@5
+            @semantic-release/changelog@6
+            @semantic-release/git@10
+            @semantic-release/exec@6
         env:
           GITHUB_TOKEN: ${{ secrets.REPO_PUSH_TOKEN }} # for semantic release git push access 
           FIREBASE_APP_ID: ${{ secrets.FIREBASE_APP_ID }} # for firebase app distribution 

--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Setup environment for building and releasing app 
-        uses: ./.github/actions/prepare-for-app-build.yml
+        uses: ./.github/actions/prepare-for-app-build
       
       # Perform git related tasks inside of semantic-release because `git config user...` is already setup. It's easier to run commands in there with exec plugin.
       - name: Deploy app via semantic release 

--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Setup environment for building and releasing app 
         uses: ./.github/actions/prepare-for-app-build
-        env:
+        with:
           GOOGLE_SERVICES_BASE64: "${{ secrets.GOOGLE_SERVICES_BASE64 }}"
           ENV_FILE_B64: "${{ secrets.ENV_FILE_B64 }}"
           FIREBASE_APP_DISTRIBUTION_GOOGLE_AUTH: ${{ secrets.FIREBASE_APP_DISTRIBUTION_GOOGLE_AUTH }}

--- a/.github/workflows/manual-build.yml
+++ b/.github/workflows/manual-build.yml
@@ -28,6 +28,11 @@ jobs:
           
       - name: Setup environment for building and releasing app 
         uses: ./.github/actions/prepare-for-app-build
+        env:
+          GOOGLE_SERVICES_BASE64: "${{ secrets.GOOGLE_SERVICES_BASE64 }}"
+          ENV_FILE_B64: "${{ secrets.ENV_FILE_B64 }}"
+          FIREBASE_APP_DISTRIBUTION_GOOGLE_AUTH: ${{ secrets.FIREBASE_APP_DISTRIBUTION_GOOGLE_AUTH }}
+          MATCH_GOOGLE_CLOUD_KEYS_B64: ${{ secrets.MATCH_GOOGLE_CLOUD_KEYS_B64 }}  
 
       - name: Build and re-release app 
         uses: maierj/fastlane-action@v2.0.1

--- a/.github/workflows/manual-build.yml
+++ b/.github/workflows/manual-build.yml
@@ -1,0 +1,36 @@
+# Deploy the app to stable. Not builds for development/QA
+name: Manually build latest stable 
+on: 
+  workflow_dispatch: # manually run the action
+
+env:
+  XCODE_VERSION: "13.0"
+  GITHUB_CONTEXT: ${{ toJSON(github) }} # used by fastlane for deploying app 
+
+jobs:
+  deploy-app:
+    name: Re-release the latest stable build 
+    runs-on: macos-11
+    steps:
+      - name: Get latest git tag 
+        uses: octokit/request-action@v2.1.4
+        id: get_latest_release
+        with:
+          route: GET /repos/customerio/RemoteHabits-iOS/releases/latest
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}                    
+      - run: echo "LATEST_GIT_TAG=${{ steps.get_latest_release.outputs.data.tag_name }}" >> $GITHUB_ENV      
+
+      - name: Checkout latest git tag 
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ env.LATEST_GIT_TAG }}
+          
+      - name: Setup environment for building and releasing app 
+        uses: ./.github/actions/prepare-for-app-build.yml
+
+      - name: Build and re-release app 
+        uses: maierj/fastlane-action@v2.0.1
+        with:
+          lane: 'deploy_app version:${{ env.LATEST_GIT_TAG }}'
+          skip-tracking: true

--- a/.github/workflows/manual-build.yml
+++ b/.github/workflows/manual-build.yml
@@ -27,7 +27,7 @@ jobs:
           ref: ${{ env.LATEST_GIT_TAG }}
           
       - name: Setup environment for building and releasing app 
-        uses: ./.github/actions/prepare-for-app-build.yml
+        uses: ./.github/actions/prepare-for-app-build
 
       - name: Build and re-release app 
         uses: maierj/fastlane-action@v2.0.1

--- a/.github/workflows/manual-build.yml
+++ b/.github/workflows/manual-build.yml
@@ -28,7 +28,7 @@ jobs:
           
       - name: Setup environment for building and releasing app 
         uses: ./.github/actions/prepare-for-app-build
-        env:
+        with:
           GOOGLE_SERVICES_BASE64: "${{ secrets.GOOGLE_SERVICES_BASE64 }}"
           ENV_FILE_B64: "${{ secrets.ENV_FILE_B64 }}"
           FIREBASE_APP_DISTRIBUTION_GOOGLE_AUTH: ${{ secrets.FIREBASE_APP_DISTRIBUTION_GOOGLE_AUTH }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Setup environment for building and releasing app 
       uses: ./.github/actions/prepare-for-app-build
-      env:
+      with:
         GOOGLE_SERVICES_BASE64: "${{ secrets.GOOGLE_SERVICES_BASE64 }}"
         ENV_FILE_B64: "${{ secrets.ENV_FILE_B64 }}"
         FIREBASE_APP_DISTRIBUTION_GOOGLE_AUTH: ${{ secrets.FIREBASE_APP_DISTRIBUTION_GOOGLE_AUTH }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,32 +8,16 @@ on:
 
 env:
   XCODE_VERSION: "13.0"
-  GITHUB_CONTEXT: ${{ toJSON(github) }}
+  GITHUB_CONTEXT: ${{ toJSON(github) }} # used by fastlane for deploying app 
 
 jobs:
   deploy-builds:
     runs-on: macos-11
     name: Deploy development builds 
-    # skip if '[skip ci]' exists in commit message 
-    if: ${{ !contains(format('{0} {1}', github.event.head_commit.message, github.event.pull_request.title), '[skip ci]') }}
     steps:
     - uses: actions/checkout@v2
-    - name: Prepare app for building and deploying 
-      run: |
-        echo "${{ secrets.GOOGLE_SERVICES_BASE64 }}" | base64 -d > "Remote Habits/GoogleService-Info.plist"
-        echo "${{ secrets.ENV_FILE_B64 }}" | base64 -d > "Remote Habits/Env.swift"
-        echo "${{ secrets.FIREBASE_APP_DISTRIBUTION_GOOGLE_AUTH }}" | base64 -d > firebase_appdistribution_service_account.json
-        echo "${{ secrets.MATCH_GOOGLE_CLOUD_KEYS_B64 }}" | base64 -d > gc_keys.json
-      env:
-        GOOGLE_SERVICES_BASE64: "${{ secrets.GOOGLE_SERVICES_BASE64 }}"
-        ENV_FILE_B64: "${{ secrets.ENV_FILE_B64 }}"
-        FIREBASE_APP_DISTRIBUTION_GOOGLE_AUTH: ${{ secrets.FIREBASE_APP_DISTRIBUTION_GOOGLE_AUTH }}
-        MATCH_GOOGLE_CLOUD_KEYS_B64: ${{ secrets.MATCH_GOOGLE_CLOUD_KEYS_B64 }}
-    - name: Setup Ruby to run Fastlane 
-      uses: ruby/setup-ruby@v1 
-      with:
-        ruby-version: 2.7.2
-        bundler-cache: true # runs 'bundle install' and caches installed gems automatically            
+    - name: Setup environment for building and releasing app 
+      uses: ./.github/actions/prepare-for-app-build.yml         
 
     - name: Deploy development build via Fastlane 
       uses: maierj/fastlane-action@v2.0.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,11 @@ jobs:
     - uses: actions/checkout@v2
     - name: Setup environment for building and releasing app 
       uses: ./.github/actions/prepare-for-app-build
+      env:
+        GOOGLE_SERVICES_BASE64: "${{ secrets.GOOGLE_SERVICES_BASE64 }}"
+        ENV_FILE_B64: "${{ secrets.ENV_FILE_B64 }}"
+        FIREBASE_APP_DISTRIBUTION_GOOGLE_AUTH: ${{ secrets.FIREBASE_APP_DISTRIBUTION_GOOGLE_AUTH }}
+        MATCH_GOOGLE_CLOUD_KEYS_B64: ${{ secrets.MATCH_GOOGLE_CLOUD_KEYS_B64 }}  
 
     - name: Deploy development build via Fastlane 
       uses: maierj/fastlane-action@v2.0.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Setup environment for building and releasing app 
-      uses: ./.github/actions/prepare-for-app-build.yml         
+      uses: ./.github/actions/prepare-for-app-build
 
     - name: Deploy development build via Fastlane 
       uses: maierj/fastlane-action@v2.0.1


### PR DESCRIPTION
* Adds a new workflow that allows anyone to manually re-build and deploy the latest git tag deployment of the app. 
* Refactor to re-use some of the boilerplate used in the 3 workflows where we build and deploy the app. 