### PR TITLE
fix: get app to compile from removing SDK classes

### DIFF
--- a/Remote Habits/autogenerated/AutoDependencyInjection.generated.swift
+++ b/Remote Habits/autogenerated/AutoDependencyInjection.generated.swift
@@ -70,7 +70,6 @@ enum Dependency: CaseIterable {
     case messagingPush
     case profileViewModel
     case trackerViewModel
-    case tracking
     case userDefaults
 }
 
@@ -120,7 +119,6 @@ class DI {
         case .messagingPush: return messagingPush as! T
         case .profileViewModel: return profileViewModel as! T
         case .trackerViewModel: return trackerViewModel as! T
-        case .tracking: return tracking as! T
         case .userDefaults: return userDefaults as! T
         }
     }
@@ -240,14 +238,6 @@ class DI {
 
     private var newTrackerViewModel: TrackerViewModel {
         TrackerViewModel(cio: customerIO)
-    }
-
-    // Tracking (custom. property getter provided via extension)
-    internal var tracking: Tracking {
-        if let overridenDep = overrides[.tracking] {
-            return overridenDep as! Tracking
-        }
-        return customTracking
     }
 
     // UserDefaults (custom. property getter provided via extension)

--- a/Remote Habits/autogenerated/DIDependencies.swift
+++ b/Remote Habits/autogenerated/DIDependencies.swift
@@ -3,31 +3,13 @@ import CioTracking
 import Foundation
 import UIKit
 
-// sourcery: InjectRegister = "Tracking"
-// sourcery: InjectCustom
-extension Tracking {}
-
-extension DI {
-    var customTracking: Tracking {
-        Tracking(customerIO: customerIO)
-    }
-}
-
 // sourcery: InjectRegister = "CustomerIO"
 // sourcery: InjectCustom
 extension CustomerIO {}
 
 extension DI {
     var customCustomerIO: CustomerIO {
-        let region = Env.customerIORegion == "us" ? Region.US : Region.EU
-
-        let cio = CustomerIO(siteId: Env.customerIOSiteId, apiKey: Env.customerIOApiKey, region: region)
-
-        cio.config {
-            $0.logLevel = .debug
-        }
-
-        return cio
+        CustomerIO.shared
     }
 }
 
@@ -37,7 +19,7 @@ extension MessagingPush {}
 
 extension DI {
     var customMessagingPush: MessagingPush {
-        MessagingPush(customerIO: DI.shared.customerIO)
+        MessagingPush.shared
     }
 }
 


### PR DESCRIPTION
Some classes were removed in the SDK. This PR fixes the app from not being able to build. 