### PR TITLE
fix: switch workspace not working as expected 

### DIFF
--- a/Remote Habits/AppDelegate.swift
+++ b/Remote Habits/AppDelegate.swift
@@ -23,7 +23,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         CustomerIO.config {
             $0.logLevel = .debug
             $0.autoTrackScreenViews = true
-//            $0.trackingApiUrl = "https://track-debugger.devzilla.customerio.dev"
         }
         // Step 2: To display rich push notification
         UNUserNotificationCenter.current().delegate = self

--- a/Remote Habits/AppDelegate.swift
+++ b/Remote Habits/AppDelegate.swift
@@ -23,6 +23,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         CustomerIO.config {
             $0.logLevel = .debug
             $0.autoTrackScreenViews = true
+//            $0.trackingApiUrl = "https://track-debugger.devzilla.customerio.dev"
         }
         // Step 2: To display rich push notification
         UNUserNotificationCenter.current().delegate = self

--- a/Remote Habits/Extension/ButtonExtension.swift
+++ b/Remote Habits/Extension/ButtonExtension.swift
@@ -9,7 +9,7 @@ extension UIButton {
     func customiseFloating() {
         let xCoordinates = Int(UIScreen.main.bounds.width - 56)
         let widthHeight = 40
-        frame = CGRect(x: xCoordinates, y: 50, width: widthHeight, height: widthHeight)
+        frame = CGRect(x: xCoordinates, y: 10, width: widthHeight, height: widthHeight)
         setImage(UIImage(named: "settings")!, for: .normal)
         self.layer.cornerRadius = CGFloat(widthHeight / 2)
 

--- a/Remote Habits/Router/DashboardRouter.swift
+++ b/Remote Habits/Router/DashboardRouter.swift
@@ -6,6 +6,7 @@ protocol DashboardRouting {
     func routeToSwitchWorkspace(withData: WorkspaceData?)
     func routeToLogin()
     func routeSetToLogin()
+    func routeToConfigureCioSdk()
 }
 
 class DashboardRouter: DashboardRouting {
@@ -37,5 +38,11 @@ class DashboardRouter: DashboardRouting {
     func routeSetToLogin() {
         dashboardViewController?.navigationController?.setViewControllers([LoginViewController.newInstance()],
                                                                           animated: true)
+    }
+    
+    func routeToConfigureCioSdk() {
+        let viewController = ConfigureCioSdkViewController.newInstance()
+        let navigation = UINavigationController(rootViewController: viewController)
+        dashboardViewController?.present(navigation, animated: true, completion: nil)
     }
 }

--- a/Remote Habits/Router/LoginRouter.swift
+++ b/Remote Habits/Router/LoginRouter.swift
@@ -4,7 +4,6 @@ import UIKit
 protocol LoginRouting {
     func routeToDashboard()
     func routeToWorkspace(withData: WorkspaceData?)
-    func routeToConfigureCioSdk()
 }
 
 class LoginRouter: LoginRouting {
@@ -19,12 +18,6 @@ class LoginRouter: LoginRouting {
     func routeToWorkspace(withData workspaceData: WorkspaceData?) {
         let viewController = SwitchWorkspaceViewController.newInstance()
         viewController.workspaceData = workspaceData
-        let navigation = UINavigationController(rootViewController: viewController)
-        loginViewController?.present(navigation, animated: true, completion: nil)
-    }
-
-    func routeToConfigureCioSdk() {
-        let viewController = ConfigureCioSdkViewController.newInstance()
         let navigation = UINavigationController(rootViewController: viewController)
         loginViewController?.present(navigation, animated: true, completion: nil)
     }

--- a/Remote Habits/View/DashboardViewController.swift
+++ b/Remote Habits/View/DashboardViewController.swift
@@ -10,7 +10,7 @@ class DashboardViewController: BaseViewController {
     @IBOutlet var dashboardTableView: UITableView!
 
     // MARK: - --VARIABLES--
-
+    var floatingButton: UIButton!
     let remoteHabitsData = RemoteHabitsData()
     var dashboardHeaders: [HabitHeadersInfo] = .init()
     var isSourceLogin: Bool = false
@@ -28,6 +28,7 @@ class DashboardViewController: BaseViewController {
         addNotifierObserver()
         addDefaultBackground()
         setupDashboardTableView()
+        floatingSettingButton()
         // Do any additional setup after loading the view.
     }
 
@@ -178,5 +179,19 @@ extension DashboardViewController: DashboardActionHandler {
 
     func switchWorkspace() {
         dashboardRouter?.routeToSwitchWorkspace(withData: nil)
+    }
+    
+    @objc func floatingButtonTapped() {
+        dashboardRouter?.routeToConfigureCioSdk()
+    }
+}
+
+
+extension DashboardViewController {
+    func floatingSettingButton() {
+        floatingButton = UIButton(type: .custom)
+        floatingButton.customiseFloating()
+        floatingButton.addTarget(self, action: #selector(DashboardViewController.floatingButtonTapped), for: .touchUpInside)
+        view.addSubview(floatingButton)
     }
 }

--- a/Remote Habits/View/LoginViewController.swift
+++ b/Remote Habits/View/LoginViewController.swift
@@ -238,14 +238,3 @@ extension LoginViewController: UITextFieldDelegate {
         }
     }
 }
-
-// MARK: - Floating Button
-
-extension LoginViewController {
-    func floatingSettingButton() {
-        floatingButton = UIButton(type: .custom)
-        floatingButton.customiseFloating()
-        floatingButton.addTarget(self, action: #selector(LoginViewController.floatingButtonTapped), for: .touchUpInside)
-        view.addSubview(floatingButton)
-    }
-}

--- a/Remote Habits/View/LoginViewController.swift
+++ b/Remote Habits/View/LoginViewController.swift
@@ -32,7 +32,6 @@ class LoginViewController: BaseViewController {
         super.viewDidLoad()
         // Do any additional setup after loading the view.
 
-        floatingSettingButton()
         configureLoginRouter()
         addNotifierObserver()
         addLoginBackground()

--- a/Remote Habits/View/LoginViewController.swift
+++ b/Remote Habits/View/LoginViewController.swift
@@ -18,7 +18,6 @@ class LoginViewController: BaseViewController {
 
     // MARK: - --VARIABLES--
 
-    var floatingButton: UIButton!
     var userManager = DI.shared.userManager
     var textFields: [SkyFloatingLabelTextFieldWithIcon] = []
     var profileViewModel = DI.shared.profileViewModel
@@ -220,10 +219,6 @@ class LoginViewController: BaseViewController {
                     self.actOnError(toShow: true)
                 }
             }
-    }
-
-    @objc func floatingButtonTapped() {
-        loginRouter?.routeToConfigureCioSdk()
     }
 }
 

--- a/Remote Habits/View/SwitchWorkspaceViewController.swift
+++ b/Remote Habits/View/SwitchWorkspaceViewController.swift
@@ -175,5 +175,7 @@ class SwitchWorkspaceViewController: BaseViewController, UITextFieldDelegate {
         Env.customerIOSiteId = siteId
         userManager.apiKey = apiKey
         Env.customerIOApiKey = apiKey
+        
+        CustomerIO.initialize(siteId: siteId, apiKey: apiKey, region: Region.US)
     }
 }


### PR DESCRIPTION
closes: https://github.com/customerio/issues/issues/7525


In Remote Habits, on entering new site id & api key, the credentials were validated but not updated correctly. The user had to force kill the app & relaunch it to see the effective change. 

This fix provides a solution to switch workspace, validate & update the credentials without the requirement of relaunching the app which was a workaround as mentioned in the ticket above


With this PR, the settings button to update the SDK configuration is now available on the Dashboard screen which was previously on the Login Screen.